### PR TITLE
Remove pulp.h include

### DIFF
--- a/XpulpNN-mixed/32bit/include/pulp_nn_utils.h
+++ b/XpulpNN-mixed/32bit/include/pulp_nn_utils.h
@@ -23,9 +23,6 @@
 #define __PULPNN_UTILS__
 
 #include "pmsis.h"
-#ifdef GAP_SDK
-#include "pulp.h"
-#endif
 
 #define bitext(x,size,off)                                      __builtin_pulp_bextract(x,size,off)
 #define bitextu(x,size,off)                                     __builtin_pulp_bextractu(x,size,off)

--- a/XpulpNN-mixed/64bit/include/pulp_nn_utils.h
+++ b/XpulpNN-mixed/64bit/include/pulp_nn_utils.h
@@ -23,9 +23,6 @@
 #define __PULPNN_UTILS__
 
 #include "pmsis.h"
-#ifdef GAP_SDK
-#include "pulp.h"
-#endif
 
 #define bitext(x,size,off)                                      __builtin_pulp_bextract(x,size,off)
 #define bitextu(x,size,off)                                     __builtin_pulp_bextractu(x,size,off)

--- a/XpulpNN/32bit/include/pulp_nn_utils.h
+++ b/XpulpNN/32bit/include/pulp_nn_utils.h
@@ -23,9 +23,6 @@
 #define __PULPNN_UTILS__
 
 #include "pmsis.h"
-#ifdef GAP_SDK
-#include "pulp.h"
-#endif
 
 #define bitext(x,size,off)                                      __builtin_pulp_bextract(x,size,off)
 #define bitextu(x,size,off)                                     __builtin_pulp_bextractu(x,size,off)

--- a/XpulpNN/64bit/include/pulp_nn_utils.h
+++ b/XpulpNN/64bit/include/pulp_nn_utils.h
@@ -23,9 +23,6 @@
 #define __PULPNN_UTILS__
 
 #include "pmsis.h"
-#ifdef GAP_SDK
-#include "pulp.h"
-#endif
 
 #define bitext(x,size,off)                                      __builtin_pulp_bextract(x,size,off)
 #define bitextu(x,size,off)                                     __builtin_pulp_bextractu(x,size,off)

--- a/XpulpV2/32bit/include/pulp_nn_utils.h
+++ b/XpulpV2/32bit/include/pulp_nn_utils.h
@@ -23,9 +23,6 @@
 #define __PULPNN_UTILS__
 
 #include "pmsis.h"
-#ifdef GAP_SDK
-#include "pulp.h"
-#endif
 
 #define bitext(x,size,off)                                      __builtin_pulp_bextract(x,size,off)
 #define bitextu(x,size,off)                                     __builtin_pulp_bextractu(x,size,off)

--- a/XpulpV2/64bit/include/pulp_nn_utils.h
+++ b/XpulpV2/64bit/include/pulp_nn_utils.h
@@ -23,9 +23,6 @@
 #define __PULPNN_UTILS__
 
 #include "pmsis.h"
-#ifdef GAP_SDK
-#include "pulp.h"
-#endif
 
 #define bitext(x,size,off)                                      __builtin_pulp_bextract(x,size,off)
 #define bitextu(x,size,off)                                     __builtin_pulp_bextractu(x,size,off)

--- a/generators/templates/pulp_nn_utils_h.t
+++ b/generators/templates/pulp_nn_utils_h.t
@@ -31,9 +31,6 @@ else:
 #define __PULPNN_UTILS__
 
 #include "pmsis.h"
-#ifdef GAP_SDK
-#include "pulp.h"
-#endif
 
 #define bitext(x,size,off)                                      __builtin_pulp_bextract(x,size,off)
 #define bitextu(x,size,off)                                     __builtin_pulp_bextractu(x,size,off)


### PR DESCRIPTION
It makes no sense to include `pulp.h` in GAP_SDK. Fails compilation for GAP9.