### PR TITLE
OPEN: Add support for leftover handling in 8-Bit Add kernels

### DIFF
--- a/XpulpNN-mixed/32bit/include/pulp_nn_utils.h
+++ b/XpulpNN-mixed/32bit/include/pulp_nn_utils.h
@@ -29,7 +29,11 @@
 
 #define bitext(x,size,off)                                      __builtin_pulp_bextract(x,size,off)
 #define bitextu(x,size,off)                                     __builtin_pulp_bextractu(x,size,off)
+#ifdef __clang__
+#define bitins(dst,not_mask_imm,src,mask_imm,off)               __builtin_binsert(dst,not_mask_imm,src,mask_imm,off)
+#else
 #define bitins(dst,not_mask_imm,src,mask_imm,off)               __builtin_pulp_binsert(dst,not_mask_imm,src,mask_imm,off)
+#endif
 #define pack(x,y,z,t)                                           __builtin_pulp_pack4(x,y,z,t)
 #define max4(a,b)                                               __builtin_pulp_maxu4(a,b)
 #define maxs4(a, b)                                             __builtin_pulp_max4(a, b)

--- a/XpulpNN-mixed/32bit/src/Add/xpulp_nn_add_i8_i8_i8.c
+++ b/XpulpNN-mixed/32bit/src/Add/xpulp_nn_add_i8_i8_i8.c
@@ -178,5 +178,27 @@ void __attribute__ ((noinline)) xpulp_nn_add_i8_i8_i8(
         *pOutBuffer = (int8_t) out4;
         pOutBuffer++;
     }
+    // SCHEREMO: Cleanup leftovers, not doing it with this codebase for sub-byte formats
+    for (int i=0; i<(((stop-start) * ch_im_out_r * dim_im_in_x) % 4); i++){
+        in1_rq1 = ((*(target1)) * in1_mul + in1_add) >> in1_shift;
+        in2_rq1 = ((*(target2)) * in2_mul + in2_add) >> in2_shift;
+
+        // SCHEREMO: Maybe it's just LLVM, but unless I hack 3 non-unrolled nops in here, stuff fails
+        #pragma nounroll
+        for (int j = 0; j < 3; j++) {
+    	    asm volatile("nop" ::);
+        }
+
+        target1++;
+        target2++;
+        sum1 = clips8(in1_rq1) + clips8(in2_rq1);
+        if (out_requant_flag) {
+	        sum1 = (sum1 * out_mul + out_add) >> out_shift;
+        }
+
+        out1 = clips8(sum1);
+        *pOutBuffer = (int8_t)out1;
+        pOutBuffer++;
+    }
    pi_cl_team_barrier(0);
 }

--- a/XpulpNN-mixed/32bit/src/Add/xpulp_nn_add_i8_i8_u8.c
+++ b/XpulpNN-mixed/32bit/src/Add/xpulp_nn_add_i8_i8_u8.c
@@ -178,5 +178,27 @@ void __attribute__ ((noinline)) xpulp_nn_add_i8_i8_u8(
         *pOutBuffer = (uint8_t) out4;
         pOutBuffer++;
     }
+    // SCHEREMO: Cleanup leftovers, not doing it with this codebase for sub-byte formats
+    for (int i=0; i<(((stop-start) * ch_im_out_r * dim_im_in_x) % 4); i++){
+        in1_rq1 = ((*(target1)) * in1_mul + in1_add) >> in1_shift;
+        in2_rq1 = ((*(target2)) * in2_mul + in2_add) >> in2_shift;
+
+        // SCHEREMO: Maybe it's just LLVM, but unless I hack 3 non-unrolled nops in here, stuff fails
+        #pragma nounroll
+        for (int j = 0; j < 3; j++) {
+    	    asm volatile("nop" ::);
+        }
+
+        target1++;
+        target2++;
+        sum1 = clips8(in1_rq1) + clips8(in2_rq1);
+        if (out_requant_flag) {
+	        sum1 = (sum1 * out_mul + out_add) >> out_shift;
+        }
+
+        out1 = clip8(sum1);
+        *pOutBuffer = (uint8_t)out1;
+        pOutBuffer++;
+    }
    pi_cl_team_barrier(0);
 }

--- a/XpulpNN-mixed/32bit/src/Add/xpulp_nn_add_i8_u8_i8.c
+++ b/XpulpNN-mixed/32bit/src/Add/xpulp_nn_add_i8_u8_i8.c
@@ -178,5 +178,27 @@ void __attribute__ ((noinline)) xpulp_nn_add_i8_u8_i8(
         *pOutBuffer = (int8_t) out4;
         pOutBuffer++;
     }
+    // SCHEREMO: Cleanup leftovers, not doing it with this codebase for sub-byte formats
+    for (int i=0; i<(((stop-start) * ch_im_out_r * dim_im_in_x) % 4); i++){
+        in1_rq1 = ((*(target1)) * in1_mul + in1_add) >> in1_shift;
+        in2_rq1 = ((*(target2)) * in2_mul + in2_add) >> in2_shift;
+
+        // SCHEREMO: Maybe it's just LLVM, but unless I hack 3 non-unrolled nops in here, stuff fails
+        #pragma nounroll
+        for (int j = 0; j < 3; j++) {
+    	    asm volatile("nop" ::);
+        }
+
+        target1++;
+        target2++;
+        sum1 = clips8(in1_rq1) + clip8(in2_rq1);
+        if (out_requant_flag) {
+	        sum1 = (sum1 * out_mul + out_add) >> out_shift;
+        }
+
+        out1 = clips8(sum1);
+        *pOutBuffer = (int8_t)out1;
+        pOutBuffer++;
+    }
    pi_cl_team_barrier(0);
 }

--- a/XpulpNN-mixed/32bit/src/Add/xpulp_nn_add_i8_u8_u8.c
+++ b/XpulpNN-mixed/32bit/src/Add/xpulp_nn_add_i8_u8_u8.c
@@ -178,5 +178,27 @@ void __attribute__ ((noinline)) xpulp_nn_add_i8_u8_u8(
         *pOutBuffer = (uint8_t) out4;
         pOutBuffer++;
     }
+    // SCHEREMO: Cleanup leftovers, not doing it with this codebase for sub-byte formats
+    for (int i=0; i<(((stop-start) * ch_im_out_r * dim_im_in_x) % 4); i++){
+        in1_rq1 = ((*(target1)) * in1_mul + in1_add) >> in1_shift;
+        in2_rq1 = ((*(target2)) * in2_mul + in2_add) >> in2_shift;
+
+        // SCHEREMO: Maybe it's just LLVM, but unless I hack 3 non-unrolled nops in here, stuff fails
+        #pragma nounroll
+        for (int j = 0; j < 3; j++) {
+    	    asm volatile("nop" ::);
+        }
+
+        target1++;
+        target2++;
+        sum1 = clips8(in1_rq1) + clip8(in2_rq1);
+        if (out_requant_flag) {
+	        sum1 = (sum1 * out_mul + out_add) >> out_shift;
+        }
+
+        out1 = clip8(sum1);
+        *pOutBuffer = (uint8_t)out1;
+        pOutBuffer++;
+    }
    pi_cl_team_barrier(0);
 }

--- a/XpulpNN-mixed/32bit/src/Add/xpulp_nn_add_u8_i8_i8.c
+++ b/XpulpNN-mixed/32bit/src/Add/xpulp_nn_add_u8_i8_i8.c
@@ -178,5 +178,27 @@ void __attribute__ ((noinline)) xpulp_nn_add_u8_i8_i8(
         *pOutBuffer = (int8_t) out4;
         pOutBuffer++;
     }
+    // SCHEREMO: Cleanup leftovers, not doing it with this codebase for sub-byte formats
+    for (int i=0; i<(((stop-start) * ch_im_out_r * dim_im_in_x) % 4); i++){
+        in1_rq1 = ((*(target1)) * in1_mul + in1_add) >> in1_shift;
+        in2_rq1 = ((*(target2)) * in2_mul + in2_add) >> in2_shift;
+
+        // SCHEREMO: Maybe it's just LLVM, but unless I hack 3 non-unrolled nops in here, stuff fails
+        #pragma nounroll
+        for (int j = 0; j < 3; j++) {
+    	    asm volatile("nop" ::);
+        }
+
+        target1++;
+        target2++;
+        sum1 = clip8(in1_rq1) + clips8(in2_rq1);
+        if (out_requant_flag) {
+	        sum1 = (sum1 * out_mul + out_add) >> out_shift;
+        }
+
+        out1 = clips8(sum1);
+        *pOutBuffer = (int8_t)out1;
+        pOutBuffer++;
+    }
    pi_cl_team_barrier(0);
 }

--- a/XpulpNN-mixed/32bit/src/Add/xpulp_nn_add_u8_i8_u8.c
+++ b/XpulpNN-mixed/32bit/src/Add/xpulp_nn_add_u8_i8_u8.c
@@ -178,5 +178,27 @@ void __attribute__ ((noinline)) xpulp_nn_add_u8_i8_u8(
         *pOutBuffer = (uint8_t) out4;
         pOutBuffer++;
     }
+    // SCHEREMO: Cleanup leftovers, not doing it with this codebase for sub-byte formats
+    for (int i=0; i<(((stop-start) * ch_im_out_r * dim_im_in_x) % 4); i++){
+        in1_rq1 = ((*(target1)) * in1_mul + in1_add) >> in1_shift;
+        in2_rq1 = ((*(target2)) * in2_mul + in2_add) >> in2_shift;
+
+        // SCHEREMO: Maybe it's just LLVM, but unless I hack 3 non-unrolled nops in here, stuff fails
+        #pragma nounroll
+        for (int j = 0; j < 3; j++) {
+    	    asm volatile("nop" ::);
+        }
+
+        target1++;
+        target2++;
+        sum1 = clip8(in1_rq1) + clips8(in2_rq1);
+        if (out_requant_flag) {
+	        sum1 = (sum1 * out_mul + out_add) >> out_shift;
+        }
+
+        out1 = clip8(sum1);
+        *pOutBuffer = (uint8_t)out1;
+        pOutBuffer++;
+    }
    pi_cl_team_barrier(0);
 }

--- a/XpulpNN-mixed/32bit/src/Add/xpulp_nn_add_u8_u8_i8.c
+++ b/XpulpNN-mixed/32bit/src/Add/xpulp_nn_add_u8_u8_i8.c
@@ -178,5 +178,27 @@ void __attribute__ ((noinline)) xpulp_nn_add_u8_u8_i8(
         *pOutBuffer = (int8_t) out4;
         pOutBuffer++;
     }
+    // SCHEREMO: Cleanup leftovers, not doing it with this codebase for sub-byte formats
+    for (int i=0; i<(((stop-start) * ch_im_out_r * dim_im_in_x) % 4); i++){
+        in1_rq1 = ((*(target1)) * in1_mul + in1_add) >> in1_shift;
+        in2_rq1 = ((*(target2)) * in2_mul + in2_add) >> in2_shift;
+
+        // SCHEREMO: Maybe it's just LLVM, but unless I hack 3 non-unrolled nops in here, stuff fails
+        #pragma nounroll
+        for (int j = 0; j < 3; j++) {
+    	    asm volatile("nop" ::);
+        }
+
+        target1++;
+        target2++;
+        sum1 = clip8(in1_rq1) + clip8(in2_rq1);
+        if (out_requant_flag) {
+	        sum1 = (sum1 * out_mul + out_add) >> out_shift;
+        }
+
+        out1 = clips8(sum1);
+        *pOutBuffer = (int8_t)out1;
+        pOutBuffer++;
+    }
    pi_cl_team_barrier(0);
 }

--- a/XpulpNN-mixed/32bit/src/Add/xpulp_nn_add_u8_u8_u8.c
+++ b/XpulpNN-mixed/32bit/src/Add/xpulp_nn_add_u8_u8_u8.c
@@ -178,5 +178,27 @@ void __attribute__ ((noinline)) xpulp_nn_add_u8_u8_u8(
         *pOutBuffer = (uint8_t) out4;
         pOutBuffer++;
     }
+    // SCHEREMO: Cleanup leftovers, not doing it with this codebase for sub-byte formats
+    for (int i=0; i<(((stop-start) * ch_im_out_r * dim_im_in_x) % 4); i++){
+        in1_rq1 = ((*(target1)) * in1_mul + in1_add) >> in1_shift;
+        in2_rq1 = ((*(target2)) * in2_mul + in2_add) >> in2_shift;
+
+        // SCHEREMO: Maybe it's just LLVM, but unless I hack 3 non-unrolled nops in here, stuff fails
+        #pragma nounroll
+        for (int j = 0; j < 3; j++) {
+    	    asm volatile("nop" ::);
+        }
+
+        target1++;
+        target2++;
+        sum1 = clip8(in1_rq1) + clip8(in2_rq1);
+        if (out_requant_flag) {
+	        sum1 = (sum1 * out_mul + out_add) >> out_shift;
+        }
+
+        out1 = clip8(sum1);
+        *pOutBuffer = (uint8_t)out1;
+        pOutBuffer++;
+    }
    pi_cl_team_barrier(0);
 }

--- a/XpulpNN-mixed/64bit/include/pulp_nn_utils.h
+++ b/XpulpNN-mixed/64bit/include/pulp_nn_utils.h
@@ -29,7 +29,11 @@
 
 #define bitext(x,size,off)                                      __builtin_pulp_bextract(x,size,off)
 #define bitextu(x,size,off)                                     __builtin_pulp_bextractu(x,size,off)
+#ifdef __clang__
+#define bitins(dst,not_mask_imm,src,mask_imm,off)               __builtin_binsert(dst,not_mask_imm,src,mask_imm,off)
+#else
 #define bitins(dst,not_mask_imm,src,mask_imm,off)               __builtin_pulp_binsert(dst,not_mask_imm,src,mask_imm,off)
+#endif
 #define pack(x,y,z,t)                                           __builtin_pulp_pack4(x,y,z,t)
 #define max4(a,b)                                               __builtin_pulp_maxu4(a,b)
 #define maxs4(a, b)                                             __builtin_pulp_max4(a, b)

--- a/XpulpNN-mixed/64bit/src/Add/xpulp_nn_add_i8_i8_i8.c
+++ b/XpulpNN-mixed/64bit/src/Add/xpulp_nn_add_i8_i8_i8.c
@@ -178,5 +178,27 @@ void __attribute__ ((noinline)) xpulp_nn_add_i8_i8_i8(
         *pOutBuffer = (int8_t) out4;
         pOutBuffer++;
     }
+    // SCHEREMO: Cleanup leftovers, not doing it with this codebase for sub-byte formats
+    for (int i=0; i<(((stop-start) * ch_im_out_r * dim_im_in_x) % 4); i++){
+        in1_rq1 = ((*(target1)) * in1_mul + in1_add) >> in1_shift;
+        in2_rq1 = ((*(target2)) * in2_mul + in2_add) >> in2_shift;
+
+        // SCHEREMO: Maybe it's just LLVM, but unless I hack 3 non-unrolled nops in here, stuff fails
+        #pragma nounroll
+        for (int j = 0; j < 3; j++) {
+    	    asm volatile("nop" ::);
+        }
+
+        target1++;
+        target2++;
+        sum1 = clips8(in1_rq1) + clips8(in2_rq1);
+        if (out_requant_flag) {
+	        sum1 = (sum1 * out_mul + out_add) >> out_shift;
+        }
+
+        out1 = clips8(sum1);
+        *pOutBuffer = (int8_t)out1;
+        pOutBuffer++;
+    }
    pi_cl_team_barrier(0);
 }

--- a/XpulpNN-mixed/64bit/src/Add/xpulp_nn_add_i8_i8_u8.c
+++ b/XpulpNN-mixed/64bit/src/Add/xpulp_nn_add_i8_i8_u8.c
@@ -178,5 +178,27 @@ void __attribute__ ((noinline)) xpulp_nn_add_i8_i8_u8(
         *pOutBuffer = (uint8_t) out4;
         pOutBuffer++;
     }
+    // SCHEREMO: Cleanup leftovers, not doing it with this codebase for sub-byte formats
+    for (int i=0; i<(((stop-start) * ch_im_out_r * dim_im_in_x) % 4); i++){
+        in1_rq1 = ((*(target1)) * in1_mul + in1_add) >> in1_shift;
+        in2_rq1 = ((*(target2)) * in2_mul + in2_add) >> in2_shift;
+
+        // SCHEREMO: Maybe it's just LLVM, but unless I hack 3 non-unrolled nops in here, stuff fails
+        #pragma nounroll
+        for (int j = 0; j < 3; j++) {
+    	    asm volatile("nop" ::);
+        }
+
+        target1++;
+        target2++;
+        sum1 = clips8(in1_rq1) + clips8(in2_rq1);
+        if (out_requant_flag) {
+	        sum1 = (sum1 * out_mul + out_add) >> out_shift;
+        }
+
+        out1 = clip8(sum1);
+        *pOutBuffer = (uint8_t)out1;
+        pOutBuffer++;
+    }
    pi_cl_team_barrier(0);
 }

--- a/XpulpNN-mixed/64bit/src/Add/xpulp_nn_add_i8_u8_i8.c
+++ b/XpulpNN-mixed/64bit/src/Add/xpulp_nn_add_i8_u8_i8.c
@@ -178,5 +178,27 @@ void __attribute__ ((noinline)) xpulp_nn_add_i8_u8_i8(
         *pOutBuffer = (int8_t) out4;
         pOutBuffer++;
     }
+    // SCHEREMO: Cleanup leftovers, not doing it with this codebase for sub-byte formats
+    for (int i=0; i<(((stop-start) * ch_im_out_r * dim_im_in_x) % 4); i++){
+        in1_rq1 = ((*(target1)) * in1_mul + in1_add) >> in1_shift;
+        in2_rq1 = ((*(target2)) * in2_mul + in2_add) >> in2_shift;
+
+        // SCHEREMO: Maybe it's just LLVM, but unless I hack 3 non-unrolled nops in here, stuff fails
+        #pragma nounroll
+        for (int j = 0; j < 3; j++) {
+    	    asm volatile("nop" ::);
+        }
+
+        target1++;
+        target2++;
+        sum1 = clips8(in1_rq1) + clip8(in2_rq1);
+        if (out_requant_flag) {
+	        sum1 = (sum1 * out_mul + out_add) >> out_shift;
+        }
+
+        out1 = clips8(sum1);
+        *pOutBuffer = (int8_t)out1;
+        pOutBuffer++;
+    }
    pi_cl_team_barrier(0);
 }

--- a/XpulpNN-mixed/64bit/src/Add/xpulp_nn_add_i8_u8_u8.c
+++ b/XpulpNN-mixed/64bit/src/Add/xpulp_nn_add_i8_u8_u8.c
@@ -178,5 +178,27 @@ void __attribute__ ((noinline)) xpulp_nn_add_i8_u8_u8(
         *pOutBuffer = (uint8_t) out4;
         pOutBuffer++;
     }
+    // SCHEREMO: Cleanup leftovers, not doing it with this codebase for sub-byte formats
+    for (int i=0; i<(((stop-start) * ch_im_out_r * dim_im_in_x) % 4); i++){
+        in1_rq1 = ((*(target1)) * in1_mul + in1_add) >> in1_shift;
+        in2_rq1 = ((*(target2)) * in2_mul + in2_add) >> in2_shift;
+
+        // SCHEREMO: Maybe it's just LLVM, but unless I hack 3 non-unrolled nops in here, stuff fails
+        #pragma nounroll
+        for (int j = 0; j < 3; j++) {
+    	    asm volatile("nop" ::);
+        }
+
+        target1++;
+        target2++;
+        sum1 = clips8(in1_rq1) + clip8(in2_rq1);
+        if (out_requant_flag) {
+	        sum1 = (sum1 * out_mul + out_add) >> out_shift;
+        }
+
+        out1 = clip8(sum1);
+        *pOutBuffer = (uint8_t)out1;
+        pOutBuffer++;
+    }
    pi_cl_team_barrier(0);
 }

--- a/XpulpNN-mixed/64bit/src/Add/xpulp_nn_add_u8_i8_i8.c
+++ b/XpulpNN-mixed/64bit/src/Add/xpulp_nn_add_u8_i8_i8.c
@@ -178,5 +178,27 @@ void __attribute__ ((noinline)) xpulp_nn_add_u8_i8_i8(
         *pOutBuffer = (int8_t) out4;
         pOutBuffer++;
     }
+    // SCHEREMO: Cleanup leftovers, not doing it with this codebase for sub-byte formats
+    for (int i=0; i<(((stop-start) * ch_im_out_r * dim_im_in_x) % 4); i++){
+        in1_rq1 = ((*(target1)) * in1_mul + in1_add) >> in1_shift;
+        in2_rq1 = ((*(target2)) * in2_mul + in2_add) >> in2_shift;
+
+        // SCHEREMO: Maybe it's just LLVM, but unless I hack 3 non-unrolled nops in here, stuff fails
+        #pragma nounroll
+        for (int j = 0; j < 3; j++) {
+    	    asm volatile("nop" ::);
+        }
+
+        target1++;
+        target2++;
+        sum1 = clip8(in1_rq1) + clips8(in2_rq1);
+        if (out_requant_flag) {
+	        sum1 = (sum1 * out_mul + out_add) >> out_shift;
+        }
+
+        out1 = clips8(sum1);
+        *pOutBuffer = (int8_t)out1;
+        pOutBuffer++;
+    }
    pi_cl_team_barrier(0);
 }

--- a/XpulpNN-mixed/64bit/src/Add/xpulp_nn_add_u8_i8_u8.c
+++ b/XpulpNN-mixed/64bit/src/Add/xpulp_nn_add_u8_i8_u8.c
@@ -178,5 +178,27 @@ void __attribute__ ((noinline)) xpulp_nn_add_u8_i8_u8(
         *pOutBuffer = (uint8_t) out4;
         pOutBuffer++;
     }
+    // SCHEREMO: Cleanup leftovers, not doing it with this codebase for sub-byte formats
+    for (int i=0; i<(((stop-start) * ch_im_out_r * dim_im_in_x) % 4); i++){
+        in1_rq1 = ((*(target1)) * in1_mul + in1_add) >> in1_shift;
+        in2_rq1 = ((*(target2)) * in2_mul + in2_add) >> in2_shift;
+
+        // SCHEREMO: Maybe it's just LLVM, but unless I hack 3 non-unrolled nops in here, stuff fails
+        #pragma nounroll
+        for (int j = 0; j < 3; j++) {
+    	    asm volatile("nop" ::);
+        }
+
+        target1++;
+        target2++;
+        sum1 = clip8(in1_rq1) + clips8(in2_rq1);
+        if (out_requant_flag) {
+	        sum1 = (sum1 * out_mul + out_add) >> out_shift;
+        }
+
+        out1 = clip8(sum1);
+        *pOutBuffer = (uint8_t)out1;
+        pOutBuffer++;
+    }
    pi_cl_team_barrier(0);
 }

--- a/XpulpNN-mixed/64bit/src/Add/xpulp_nn_add_u8_u8_i8.c
+++ b/XpulpNN-mixed/64bit/src/Add/xpulp_nn_add_u8_u8_i8.c
@@ -178,5 +178,27 @@ void __attribute__ ((noinline)) xpulp_nn_add_u8_u8_i8(
         *pOutBuffer = (int8_t) out4;
         pOutBuffer++;
     }
+    // SCHEREMO: Cleanup leftovers, not doing it with this codebase for sub-byte formats
+    for (int i=0; i<(((stop-start) * ch_im_out_r * dim_im_in_x) % 4); i++){
+        in1_rq1 = ((*(target1)) * in1_mul + in1_add) >> in1_shift;
+        in2_rq1 = ((*(target2)) * in2_mul + in2_add) >> in2_shift;
+
+        // SCHEREMO: Maybe it's just LLVM, but unless I hack 3 non-unrolled nops in here, stuff fails
+        #pragma nounroll
+        for (int j = 0; j < 3; j++) {
+    	    asm volatile("nop" ::);
+        }
+
+        target1++;
+        target2++;
+        sum1 = clip8(in1_rq1) + clip8(in2_rq1);
+        if (out_requant_flag) {
+	        sum1 = (sum1 * out_mul + out_add) >> out_shift;
+        }
+
+        out1 = clips8(sum1);
+        *pOutBuffer = (int8_t)out1;
+        pOutBuffer++;
+    }
    pi_cl_team_barrier(0);
 }

--- a/XpulpNN-mixed/64bit/src/Add/xpulp_nn_add_u8_u8_u8.c
+++ b/XpulpNN-mixed/64bit/src/Add/xpulp_nn_add_u8_u8_u8.c
@@ -178,5 +178,27 @@ void __attribute__ ((noinline)) xpulp_nn_add_u8_u8_u8(
         *pOutBuffer = (uint8_t) out4;
         pOutBuffer++;
     }
+    // SCHEREMO: Cleanup leftovers, not doing it with this codebase for sub-byte formats
+    for (int i=0; i<(((stop-start) * ch_im_out_r * dim_im_in_x) % 4); i++){
+        in1_rq1 = ((*(target1)) * in1_mul + in1_add) >> in1_shift;
+        in2_rq1 = ((*(target2)) * in2_mul + in2_add) >> in2_shift;
+
+        // SCHEREMO: Maybe it's just LLVM, but unless I hack 3 non-unrolled nops in here, stuff fails
+        #pragma nounroll
+        for (int j = 0; j < 3; j++) {
+    	    asm volatile("nop" ::);
+        }
+
+        target1++;
+        target2++;
+        sum1 = clip8(in1_rq1) + clip8(in2_rq1);
+        if (out_requant_flag) {
+	        sum1 = (sum1 * out_mul + out_add) >> out_shift;
+        }
+
+        out1 = clip8(sum1);
+        *pOutBuffer = (uint8_t)out1;
+        pOutBuffer++;
+    }
    pi_cl_team_barrier(0);
 }

--- a/XpulpNN/32bit/include/pulp_nn_utils.h
+++ b/XpulpNN/32bit/include/pulp_nn_utils.h
@@ -29,7 +29,11 @@
 
 #define bitext(x,size,off)                                      __builtin_pulp_bextract(x,size,off)
 #define bitextu(x,size,off)                                     __builtin_pulp_bextractu(x,size,off)
+#ifdef __clang__
+#define bitins(dst,not_mask_imm,src,mask_imm,off)               __builtin_binsert(dst,not_mask_imm,src,mask_imm,off)
+#else
 #define bitins(dst,not_mask_imm,src,mask_imm,off)               __builtin_pulp_binsert(dst,not_mask_imm,src,mask_imm,off)
+#endif
 #define pack(x,y,z,t)                                           __builtin_pulp_pack4(x,y,z,t)
 #define max4(a,b)                                               __builtin_pulp_maxu4(a,b)
 #define maxs4(a, b)                                             __builtin_pulp_max4(a, b)

--- a/XpulpNN/32bit/src/Add/xpulp_nn_add_i8_i8_i8.c
+++ b/XpulpNN/32bit/src/Add/xpulp_nn_add_i8_i8_i8.c
@@ -178,5 +178,27 @@ void __attribute__ ((noinline)) xpulp_nn_add_i8_i8_i8(
         *pOutBuffer = (int8_t) out4;
         pOutBuffer++;
     }
+    // SCHEREMO: Cleanup leftovers, not doing it with this codebase for sub-byte formats
+    for (int i=0; i<(((stop-start) * ch_im_out_r * dim_im_in_x) % 4); i++){
+        in1_rq1 = ((*(target1)) * in1_mul + in1_add) >> in1_shift;
+        in2_rq1 = ((*(target2)) * in2_mul + in2_add) >> in2_shift;
+
+        // SCHEREMO: Maybe it's just LLVM, but unless I hack 3 non-unrolled nops in here, stuff fails
+        #pragma nounroll
+        for (int j = 0; j < 3; j++) {
+    	    asm volatile("nop" ::);
+        }
+
+        target1++;
+        target2++;
+        sum1 = clips8(in1_rq1) + clips8(in2_rq1);
+        if (out_requant_flag) {
+	        sum1 = (sum1 * out_mul + out_add) >> out_shift;
+        }
+
+        out1 = clips8(sum1);
+        *pOutBuffer = (int8_t)out1;
+        pOutBuffer++;
+    }
    pi_cl_team_barrier(0);
 }

--- a/XpulpNN/32bit/src/Add/xpulp_nn_add_i8_i8_u8.c
+++ b/XpulpNN/32bit/src/Add/xpulp_nn_add_i8_i8_u8.c
@@ -178,5 +178,27 @@ void __attribute__ ((noinline)) xpulp_nn_add_i8_i8_u8(
         *pOutBuffer = (uint8_t) out4;
         pOutBuffer++;
     }
+    // SCHEREMO: Cleanup leftovers, not doing it with this codebase for sub-byte formats
+    for (int i=0; i<(((stop-start) * ch_im_out_r * dim_im_in_x) % 4); i++){
+        in1_rq1 = ((*(target1)) * in1_mul + in1_add) >> in1_shift;
+        in2_rq1 = ((*(target2)) * in2_mul + in2_add) >> in2_shift;
+
+        // SCHEREMO: Maybe it's just LLVM, but unless I hack 3 non-unrolled nops in here, stuff fails
+        #pragma nounroll
+        for (int j = 0; j < 3; j++) {
+    	    asm volatile("nop" ::);
+        }
+
+        target1++;
+        target2++;
+        sum1 = clips8(in1_rq1) + clips8(in2_rq1);
+        if (out_requant_flag) {
+	        sum1 = (sum1 * out_mul + out_add) >> out_shift;
+        }
+
+        out1 = clip8(sum1);
+        *pOutBuffer = (uint8_t)out1;
+        pOutBuffer++;
+    }
    pi_cl_team_barrier(0);
 }

--- a/XpulpNN/32bit/src/Add/xpulp_nn_add_i8_u8_i8.c
+++ b/XpulpNN/32bit/src/Add/xpulp_nn_add_i8_u8_i8.c
@@ -178,5 +178,27 @@ void __attribute__ ((noinline)) xpulp_nn_add_i8_u8_i8(
         *pOutBuffer = (int8_t) out4;
         pOutBuffer++;
     }
+    // SCHEREMO: Cleanup leftovers, not doing it with this codebase for sub-byte formats
+    for (int i=0; i<(((stop-start) * ch_im_out_r * dim_im_in_x) % 4); i++){
+        in1_rq1 = ((*(target1)) * in1_mul + in1_add) >> in1_shift;
+        in2_rq1 = ((*(target2)) * in2_mul + in2_add) >> in2_shift;
+
+        // SCHEREMO: Maybe it's just LLVM, but unless I hack 3 non-unrolled nops in here, stuff fails
+        #pragma nounroll
+        for (int j = 0; j < 3; j++) {
+    	    asm volatile("nop" ::);
+        }
+
+        target1++;
+        target2++;
+        sum1 = clips8(in1_rq1) + clip8(in2_rq1);
+        if (out_requant_flag) {
+	        sum1 = (sum1 * out_mul + out_add) >> out_shift;
+        }
+
+        out1 = clips8(sum1);
+        *pOutBuffer = (int8_t)out1;
+        pOutBuffer++;
+    }
    pi_cl_team_barrier(0);
 }

--- a/XpulpNN/32bit/src/Add/xpulp_nn_add_i8_u8_u8.c
+++ b/XpulpNN/32bit/src/Add/xpulp_nn_add_i8_u8_u8.c
@@ -178,5 +178,27 @@ void __attribute__ ((noinline)) xpulp_nn_add_i8_u8_u8(
         *pOutBuffer = (uint8_t) out4;
         pOutBuffer++;
     }
+    // SCHEREMO: Cleanup leftovers, not doing it with this codebase for sub-byte formats
+    for (int i=0; i<(((stop-start) * ch_im_out_r * dim_im_in_x) % 4); i++){
+        in1_rq1 = ((*(target1)) * in1_mul + in1_add) >> in1_shift;
+        in2_rq1 = ((*(target2)) * in2_mul + in2_add) >> in2_shift;
+
+        // SCHEREMO: Maybe it's just LLVM, but unless I hack 3 non-unrolled nops in here, stuff fails
+        #pragma nounroll
+        for (int j = 0; j < 3; j++) {
+    	    asm volatile("nop" ::);
+        }
+
+        target1++;
+        target2++;
+        sum1 = clips8(in1_rq1) + clip8(in2_rq1);
+        if (out_requant_flag) {
+	        sum1 = (sum1 * out_mul + out_add) >> out_shift;
+        }
+
+        out1 = clip8(sum1);
+        *pOutBuffer = (uint8_t)out1;
+        pOutBuffer++;
+    }
    pi_cl_team_barrier(0);
 }

--- a/XpulpNN/32bit/src/Add/xpulp_nn_add_u8_i8_i8.c
+++ b/XpulpNN/32bit/src/Add/xpulp_nn_add_u8_i8_i8.c
@@ -178,5 +178,27 @@ void __attribute__ ((noinline)) xpulp_nn_add_u8_i8_i8(
         *pOutBuffer = (int8_t) out4;
         pOutBuffer++;
     }
+    // SCHEREMO: Cleanup leftovers, not doing it with this codebase for sub-byte formats
+    for (int i=0; i<(((stop-start) * ch_im_out_r * dim_im_in_x) % 4); i++){
+        in1_rq1 = ((*(target1)) * in1_mul + in1_add) >> in1_shift;
+        in2_rq1 = ((*(target2)) * in2_mul + in2_add) >> in2_shift;
+
+        // SCHEREMO: Maybe it's just LLVM, but unless I hack 3 non-unrolled nops in here, stuff fails
+        #pragma nounroll
+        for (int j = 0; j < 3; j++) {
+    	    asm volatile("nop" ::);
+        }
+
+        target1++;
+        target2++;
+        sum1 = clip8(in1_rq1) + clips8(in2_rq1);
+        if (out_requant_flag) {
+	        sum1 = (sum1 * out_mul + out_add) >> out_shift;
+        }
+
+        out1 = clips8(sum1);
+        *pOutBuffer = (int8_t)out1;
+        pOutBuffer++;
+    }
    pi_cl_team_barrier(0);
 }

--- a/XpulpNN/32bit/src/Add/xpulp_nn_add_u8_i8_u8.c
+++ b/XpulpNN/32bit/src/Add/xpulp_nn_add_u8_i8_u8.c
@@ -178,5 +178,27 @@ void __attribute__ ((noinline)) xpulp_nn_add_u8_i8_u8(
         *pOutBuffer = (uint8_t) out4;
         pOutBuffer++;
     }
+    // SCHEREMO: Cleanup leftovers, not doing it with this codebase for sub-byte formats
+    for (int i=0; i<(((stop-start) * ch_im_out_r * dim_im_in_x) % 4); i++){
+        in1_rq1 = ((*(target1)) * in1_mul + in1_add) >> in1_shift;
+        in2_rq1 = ((*(target2)) * in2_mul + in2_add) >> in2_shift;
+
+        // SCHEREMO: Maybe it's just LLVM, but unless I hack 3 non-unrolled nops in here, stuff fails
+        #pragma nounroll
+        for (int j = 0; j < 3; j++) {
+    	    asm volatile("nop" ::);
+        }
+
+        target1++;
+        target2++;
+        sum1 = clip8(in1_rq1) + clips8(in2_rq1);
+        if (out_requant_flag) {
+	        sum1 = (sum1 * out_mul + out_add) >> out_shift;
+        }
+
+        out1 = clip8(sum1);
+        *pOutBuffer = (uint8_t)out1;
+        pOutBuffer++;
+    }
    pi_cl_team_barrier(0);
 }

--- a/XpulpNN/32bit/src/Add/xpulp_nn_add_u8_u8_i8.c
+++ b/XpulpNN/32bit/src/Add/xpulp_nn_add_u8_u8_i8.c
@@ -178,5 +178,27 @@ void __attribute__ ((noinline)) xpulp_nn_add_u8_u8_i8(
         *pOutBuffer = (int8_t) out4;
         pOutBuffer++;
     }
+    // SCHEREMO: Cleanup leftovers, not doing it with this codebase for sub-byte formats
+    for (int i=0; i<(((stop-start) * ch_im_out_r * dim_im_in_x) % 4); i++){
+        in1_rq1 = ((*(target1)) * in1_mul + in1_add) >> in1_shift;
+        in2_rq1 = ((*(target2)) * in2_mul + in2_add) >> in2_shift;
+
+        // SCHEREMO: Maybe it's just LLVM, but unless I hack 3 non-unrolled nops in here, stuff fails
+        #pragma nounroll
+        for (int j = 0; j < 3; j++) {
+    	    asm volatile("nop" ::);
+        }
+
+        target1++;
+        target2++;
+        sum1 = clip8(in1_rq1) + clip8(in2_rq1);
+        if (out_requant_flag) {
+	        sum1 = (sum1 * out_mul + out_add) >> out_shift;
+        }
+
+        out1 = clips8(sum1);
+        *pOutBuffer = (int8_t)out1;
+        pOutBuffer++;
+    }
    pi_cl_team_barrier(0);
 }

--- a/XpulpNN/32bit/src/Add/xpulp_nn_add_u8_u8_u8.c
+++ b/XpulpNN/32bit/src/Add/xpulp_nn_add_u8_u8_u8.c
@@ -178,5 +178,27 @@ void __attribute__ ((noinline)) xpulp_nn_add_u8_u8_u8(
         *pOutBuffer = (uint8_t) out4;
         pOutBuffer++;
     }
+    // SCHEREMO: Cleanup leftovers, not doing it with this codebase for sub-byte formats
+    for (int i=0; i<(((stop-start) * ch_im_out_r * dim_im_in_x) % 4); i++){
+        in1_rq1 = ((*(target1)) * in1_mul + in1_add) >> in1_shift;
+        in2_rq1 = ((*(target2)) * in2_mul + in2_add) >> in2_shift;
+
+        // SCHEREMO: Maybe it's just LLVM, but unless I hack 3 non-unrolled nops in here, stuff fails
+        #pragma nounroll
+        for (int j = 0; j < 3; j++) {
+    	    asm volatile("nop" ::);
+        }
+
+        target1++;
+        target2++;
+        sum1 = clip8(in1_rq1) + clip8(in2_rq1);
+        if (out_requant_flag) {
+	        sum1 = (sum1 * out_mul + out_add) >> out_shift;
+        }
+
+        out1 = clip8(sum1);
+        *pOutBuffer = (uint8_t)out1;
+        pOutBuffer++;
+    }
    pi_cl_team_barrier(0);
 }

--- a/XpulpNN/64bit/include/pulp_nn_utils.h
+++ b/XpulpNN/64bit/include/pulp_nn_utils.h
@@ -29,7 +29,11 @@
 
 #define bitext(x,size,off)                                      __builtin_pulp_bextract(x,size,off)
 #define bitextu(x,size,off)                                     __builtin_pulp_bextractu(x,size,off)
+#ifdef __clang__
+#define bitins(dst,not_mask_imm,src,mask_imm,off)               __builtin_binsert(dst,not_mask_imm,src,mask_imm,off)
+#else
 #define bitins(dst,not_mask_imm,src,mask_imm,off)               __builtin_pulp_binsert(dst,not_mask_imm,src,mask_imm,off)
+#endif
 #define pack(x,y,z,t)                                           __builtin_pulp_pack4(x,y,z,t)
 #define max4(a,b)                                               __builtin_pulp_maxu4(a,b)
 #define maxs4(a, b)                                             __builtin_pulp_max4(a, b)

--- a/XpulpNN/64bit/src/Add/xpulp_nn_add_i8_i8_i8.c
+++ b/XpulpNN/64bit/src/Add/xpulp_nn_add_i8_i8_i8.c
@@ -178,5 +178,27 @@ void __attribute__ ((noinline)) xpulp_nn_add_i8_i8_i8(
         *pOutBuffer = (int8_t) out4;
         pOutBuffer++;
     }
+    // SCHEREMO: Cleanup leftovers, not doing it with this codebase for sub-byte formats
+    for (int i=0; i<(((stop-start) * ch_im_out_r * dim_im_in_x) % 4); i++){
+        in1_rq1 = ((*(target1)) * in1_mul + in1_add) >> in1_shift;
+        in2_rq1 = ((*(target2)) * in2_mul + in2_add) >> in2_shift;
+
+        // SCHEREMO: Maybe it's just LLVM, but unless I hack 3 non-unrolled nops in here, stuff fails
+        #pragma nounroll
+        for (int j = 0; j < 3; j++) {
+    	    asm volatile("nop" ::);
+        }
+
+        target1++;
+        target2++;
+        sum1 = clips8(in1_rq1) + clips8(in2_rq1);
+        if (out_requant_flag) {
+	        sum1 = (sum1 * out_mul + out_add) >> out_shift;
+        }
+
+        out1 = clips8(sum1);
+        *pOutBuffer = (int8_t)out1;
+        pOutBuffer++;
+    }
    pi_cl_team_barrier(0);
 }

--- a/XpulpNN/64bit/src/Add/xpulp_nn_add_i8_i8_u8.c
+++ b/XpulpNN/64bit/src/Add/xpulp_nn_add_i8_i8_u8.c
@@ -178,5 +178,27 @@ void __attribute__ ((noinline)) xpulp_nn_add_i8_i8_u8(
         *pOutBuffer = (uint8_t) out4;
         pOutBuffer++;
     }
+    // SCHEREMO: Cleanup leftovers, not doing it with this codebase for sub-byte formats
+    for (int i=0; i<(((stop-start) * ch_im_out_r * dim_im_in_x) % 4); i++){
+        in1_rq1 = ((*(target1)) * in1_mul + in1_add) >> in1_shift;
+        in2_rq1 = ((*(target2)) * in2_mul + in2_add) >> in2_shift;
+
+        // SCHEREMO: Maybe it's just LLVM, but unless I hack 3 non-unrolled nops in here, stuff fails
+        #pragma nounroll
+        for (int j = 0; j < 3; j++) {
+    	    asm volatile("nop" ::);
+        }
+
+        target1++;
+        target2++;
+        sum1 = clips8(in1_rq1) + clips8(in2_rq1);
+        if (out_requant_flag) {
+	        sum1 = (sum1 * out_mul + out_add) >> out_shift;
+        }
+
+        out1 = clip8(sum1);
+        *pOutBuffer = (uint8_t)out1;
+        pOutBuffer++;
+    }
    pi_cl_team_barrier(0);
 }

--- a/XpulpNN/64bit/src/Add/xpulp_nn_add_i8_u8_i8.c
+++ b/XpulpNN/64bit/src/Add/xpulp_nn_add_i8_u8_i8.c
@@ -178,5 +178,27 @@ void __attribute__ ((noinline)) xpulp_nn_add_i8_u8_i8(
         *pOutBuffer = (int8_t) out4;
         pOutBuffer++;
     }
+    // SCHEREMO: Cleanup leftovers, not doing it with this codebase for sub-byte formats
+    for (int i=0; i<(((stop-start) * ch_im_out_r * dim_im_in_x) % 4); i++){
+        in1_rq1 = ((*(target1)) * in1_mul + in1_add) >> in1_shift;
+        in2_rq1 = ((*(target2)) * in2_mul + in2_add) >> in2_shift;
+
+        // SCHEREMO: Maybe it's just LLVM, but unless I hack 3 non-unrolled nops in here, stuff fails
+        #pragma nounroll
+        for (int j = 0; j < 3; j++) {
+    	    asm volatile("nop" ::);
+        }
+
+        target1++;
+        target2++;
+        sum1 = clips8(in1_rq1) + clip8(in2_rq1);
+        if (out_requant_flag) {
+	        sum1 = (sum1 * out_mul + out_add) >> out_shift;
+        }
+
+        out1 = clips8(sum1);
+        *pOutBuffer = (int8_t)out1;
+        pOutBuffer++;
+    }
    pi_cl_team_barrier(0);
 }

--- a/XpulpNN/64bit/src/Add/xpulp_nn_add_i8_u8_u8.c
+++ b/XpulpNN/64bit/src/Add/xpulp_nn_add_i8_u8_u8.c
@@ -178,5 +178,27 @@ void __attribute__ ((noinline)) xpulp_nn_add_i8_u8_u8(
         *pOutBuffer = (uint8_t) out4;
         pOutBuffer++;
     }
+    // SCHEREMO: Cleanup leftovers, not doing it with this codebase for sub-byte formats
+    for (int i=0; i<(((stop-start) * ch_im_out_r * dim_im_in_x) % 4); i++){
+        in1_rq1 = ((*(target1)) * in1_mul + in1_add) >> in1_shift;
+        in2_rq1 = ((*(target2)) * in2_mul + in2_add) >> in2_shift;
+
+        // SCHEREMO: Maybe it's just LLVM, but unless I hack 3 non-unrolled nops in here, stuff fails
+        #pragma nounroll
+        for (int j = 0; j < 3; j++) {
+    	    asm volatile("nop" ::);
+        }
+
+        target1++;
+        target2++;
+        sum1 = clips8(in1_rq1) + clip8(in2_rq1);
+        if (out_requant_flag) {
+	        sum1 = (sum1 * out_mul + out_add) >> out_shift;
+        }
+
+        out1 = clip8(sum1);
+        *pOutBuffer = (uint8_t)out1;
+        pOutBuffer++;
+    }
    pi_cl_team_barrier(0);
 }

--- a/XpulpNN/64bit/src/Add/xpulp_nn_add_u8_i8_i8.c
+++ b/XpulpNN/64bit/src/Add/xpulp_nn_add_u8_i8_i8.c
@@ -178,5 +178,27 @@ void __attribute__ ((noinline)) xpulp_nn_add_u8_i8_i8(
         *pOutBuffer = (int8_t) out4;
         pOutBuffer++;
     }
+    // SCHEREMO: Cleanup leftovers, not doing it with this codebase for sub-byte formats
+    for (int i=0; i<(((stop-start) * ch_im_out_r * dim_im_in_x) % 4); i++){
+        in1_rq1 = ((*(target1)) * in1_mul + in1_add) >> in1_shift;
+        in2_rq1 = ((*(target2)) * in2_mul + in2_add) >> in2_shift;
+
+        // SCHEREMO: Maybe it's just LLVM, but unless I hack 3 non-unrolled nops in here, stuff fails
+        #pragma nounroll
+        for (int j = 0; j < 3; j++) {
+    	    asm volatile("nop" ::);
+        }
+
+        target1++;
+        target2++;
+        sum1 = clip8(in1_rq1) + clips8(in2_rq1);
+        if (out_requant_flag) {
+	        sum1 = (sum1 * out_mul + out_add) >> out_shift;
+        }
+
+        out1 = clips8(sum1);
+        *pOutBuffer = (int8_t)out1;
+        pOutBuffer++;
+    }
    pi_cl_team_barrier(0);
 }

--- a/XpulpNN/64bit/src/Add/xpulp_nn_add_u8_i8_u8.c
+++ b/XpulpNN/64bit/src/Add/xpulp_nn_add_u8_i8_u8.c
@@ -178,5 +178,27 @@ void __attribute__ ((noinline)) xpulp_nn_add_u8_i8_u8(
         *pOutBuffer = (uint8_t) out4;
         pOutBuffer++;
     }
+    // SCHEREMO: Cleanup leftovers, not doing it with this codebase for sub-byte formats
+    for (int i=0; i<(((stop-start) * ch_im_out_r * dim_im_in_x) % 4); i++){
+        in1_rq1 = ((*(target1)) * in1_mul + in1_add) >> in1_shift;
+        in2_rq1 = ((*(target2)) * in2_mul + in2_add) >> in2_shift;
+
+        // SCHEREMO: Maybe it's just LLVM, but unless I hack 3 non-unrolled nops in here, stuff fails
+        #pragma nounroll
+        for (int j = 0; j < 3; j++) {
+    	    asm volatile("nop" ::);
+        }
+
+        target1++;
+        target2++;
+        sum1 = clip8(in1_rq1) + clips8(in2_rq1);
+        if (out_requant_flag) {
+	        sum1 = (sum1 * out_mul + out_add) >> out_shift;
+        }
+
+        out1 = clip8(sum1);
+        *pOutBuffer = (uint8_t)out1;
+        pOutBuffer++;
+    }
    pi_cl_team_barrier(0);
 }

--- a/XpulpNN/64bit/src/Add/xpulp_nn_add_u8_u8_i8.c
+++ b/XpulpNN/64bit/src/Add/xpulp_nn_add_u8_u8_i8.c
@@ -178,5 +178,27 @@ void __attribute__ ((noinline)) xpulp_nn_add_u8_u8_i8(
         *pOutBuffer = (int8_t) out4;
         pOutBuffer++;
     }
+    // SCHEREMO: Cleanup leftovers, not doing it with this codebase for sub-byte formats
+    for (int i=0; i<(((stop-start) * ch_im_out_r * dim_im_in_x) % 4); i++){
+        in1_rq1 = ((*(target1)) * in1_mul + in1_add) >> in1_shift;
+        in2_rq1 = ((*(target2)) * in2_mul + in2_add) >> in2_shift;
+
+        // SCHEREMO: Maybe it's just LLVM, but unless I hack 3 non-unrolled nops in here, stuff fails
+        #pragma nounroll
+        for (int j = 0; j < 3; j++) {
+    	    asm volatile("nop" ::);
+        }
+
+        target1++;
+        target2++;
+        sum1 = clip8(in1_rq1) + clip8(in2_rq1);
+        if (out_requant_flag) {
+	        sum1 = (sum1 * out_mul + out_add) >> out_shift;
+        }
+
+        out1 = clips8(sum1);
+        *pOutBuffer = (int8_t)out1;
+        pOutBuffer++;
+    }
    pi_cl_team_barrier(0);
 }

--- a/XpulpNN/64bit/src/Add/xpulp_nn_add_u8_u8_u8.c
+++ b/XpulpNN/64bit/src/Add/xpulp_nn_add_u8_u8_u8.c
@@ -178,5 +178,27 @@ void __attribute__ ((noinline)) xpulp_nn_add_u8_u8_u8(
         *pOutBuffer = (uint8_t) out4;
         pOutBuffer++;
     }
+    // SCHEREMO: Cleanup leftovers, not doing it with this codebase for sub-byte formats
+    for (int i=0; i<(((stop-start) * ch_im_out_r * dim_im_in_x) % 4); i++){
+        in1_rq1 = ((*(target1)) * in1_mul + in1_add) >> in1_shift;
+        in2_rq1 = ((*(target2)) * in2_mul + in2_add) >> in2_shift;
+
+        // SCHEREMO: Maybe it's just LLVM, but unless I hack 3 non-unrolled nops in here, stuff fails
+        #pragma nounroll
+        for (int j = 0; j < 3; j++) {
+    	    asm volatile("nop" ::);
+        }
+
+        target1++;
+        target2++;
+        sum1 = clip8(in1_rq1) + clip8(in2_rq1);
+        if (out_requant_flag) {
+	        sum1 = (sum1 * out_mul + out_add) >> out_shift;
+        }
+
+        out1 = clip8(sum1);
+        *pOutBuffer = (uint8_t)out1;
+        pOutBuffer++;
+    }
    pi_cl_team_barrier(0);
 }

--- a/XpulpV2/32bit/include/pulp_nn_utils.h
+++ b/XpulpV2/32bit/include/pulp_nn_utils.h
@@ -29,7 +29,11 @@
 
 #define bitext(x,size,off)                                      __builtin_pulp_bextract(x,size,off)
 #define bitextu(x,size,off)                                     __builtin_pulp_bextractu(x,size,off)
+#ifdef __clang__
+#define bitins(dst,not_mask_imm,src,mask_imm,off)               __builtin_binsert(dst,not_mask_imm,src,mask_imm,off)
+#else
 #define bitins(dst,not_mask_imm,src,mask_imm,off)               __builtin_pulp_binsert(dst,not_mask_imm,src,mask_imm,off)
+#endif
 #define pack(x,y,z,t)                                           __builtin_pulp_pack4(x,y,z,t)
 #define max4(a,b)                                               __builtin_pulp_maxu4(a,b)
 #define maxs4(a, b)                                             __builtin_pulp_max4(a, b)

--- a/XpulpV2/32bit/src/Add/pulp_nn_add_i8_i8_i8.c
+++ b/XpulpV2/32bit/src/Add/pulp_nn_add_i8_i8_i8.c
@@ -178,5 +178,27 @@ void __attribute__ ((noinline)) pulp_nn_add_i8_i8_i8(
         *pOutBuffer = (int8_t) out4;
         pOutBuffer++;
     }
+    // SCHEREMO: Cleanup leftovers, not doing it with this codebase for sub-byte formats
+    for (int i=0; i<(((stop-start) * ch_im_out_r * dim_im_in_x) % 4); i++){
+        in1_rq1 = ((*(target1)) * in1_mul + in1_add) >> in1_shift;
+        in2_rq1 = ((*(target2)) * in2_mul + in2_add) >> in2_shift;
+
+        // SCHEREMO: Maybe it's just LLVM, but unless I hack 3 non-unrolled nops in here, stuff fails
+        #pragma nounroll
+        for (int j = 0; j < 3; j++) {
+    	    asm volatile("nop" ::);
+        }
+
+        target1++;
+        target2++;
+        sum1 = clips8(in1_rq1) + clips8(in2_rq1);
+        if (out_requant_flag) {
+	        sum1 = (sum1 * out_mul + out_add) >> out_shift;
+        }
+
+        out1 = clips8(sum1);
+        *pOutBuffer = (int8_t)out1;
+        pOutBuffer++;
+    }
    pi_cl_team_barrier(0);
 }

--- a/XpulpV2/32bit/src/Add/pulp_nn_add_i8_i8_u8.c
+++ b/XpulpV2/32bit/src/Add/pulp_nn_add_i8_i8_u8.c
@@ -178,5 +178,27 @@ void __attribute__ ((noinline)) pulp_nn_add_i8_i8_u8(
         *pOutBuffer = (uint8_t) out4;
         pOutBuffer++;
     }
+    // SCHEREMO: Cleanup leftovers, not doing it with this codebase for sub-byte formats
+    for (int i=0; i<(((stop-start) * ch_im_out_r * dim_im_in_x) % 4); i++){
+        in1_rq1 = ((*(target1)) * in1_mul + in1_add) >> in1_shift;
+        in2_rq1 = ((*(target2)) * in2_mul + in2_add) >> in2_shift;
+
+        // SCHEREMO: Maybe it's just LLVM, but unless I hack 3 non-unrolled nops in here, stuff fails
+        #pragma nounroll
+        for (int j = 0; j < 3; j++) {
+    	    asm volatile("nop" ::);
+        }
+
+        target1++;
+        target2++;
+        sum1 = clips8(in1_rq1) + clips8(in2_rq1);
+        if (out_requant_flag) {
+	        sum1 = (sum1 * out_mul + out_add) >> out_shift;
+        }
+
+        out1 = clip8(sum1);
+        *pOutBuffer = (uint8_t)out1;
+        pOutBuffer++;
+    }
    pi_cl_team_barrier(0);
 }

--- a/XpulpV2/32bit/src/Add/pulp_nn_add_i8_u8_i8.c
+++ b/XpulpV2/32bit/src/Add/pulp_nn_add_i8_u8_i8.c
@@ -178,5 +178,27 @@ void __attribute__ ((noinline)) pulp_nn_add_i8_u8_i8(
         *pOutBuffer = (int8_t) out4;
         pOutBuffer++;
     }
+    // SCHEREMO: Cleanup leftovers, not doing it with this codebase for sub-byte formats
+    for (int i=0; i<(((stop-start) * ch_im_out_r * dim_im_in_x) % 4); i++){
+        in1_rq1 = ((*(target1)) * in1_mul + in1_add) >> in1_shift;
+        in2_rq1 = ((*(target2)) * in2_mul + in2_add) >> in2_shift;
+
+        // SCHEREMO: Maybe it's just LLVM, but unless I hack 3 non-unrolled nops in here, stuff fails
+        #pragma nounroll
+        for (int j = 0; j < 3; j++) {
+    	    asm volatile("nop" ::);
+        }
+
+        target1++;
+        target2++;
+        sum1 = clips8(in1_rq1) + clip8(in2_rq1);
+        if (out_requant_flag) {
+	        sum1 = (sum1 * out_mul + out_add) >> out_shift;
+        }
+
+        out1 = clips8(sum1);
+        *pOutBuffer = (int8_t)out1;
+        pOutBuffer++;
+    }
    pi_cl_team_barrier(0);
 }

--- a/XpulpV2/32bit/src/Add/pulp_nn_add_i8_u8_u8.c
+++ b/XpulpV2/32bit/src/Add/pulp_nn_add_i8_u8_u8.c
@@ -178,5 +178,27 @@ void __attribute__ ((noinline)) pulp_nn_add_i8_u8_u8(
         *pOutBuffer = (uint8_t) out4;
         pOutBuffer++;
     }
+    // SCHEREMO: Cleanup leftovers, not doing it with this codebase for sub-byte formats
+    for (int i=0; i<(((stop-start) * ch_im_out_r * dim_im_in_x) % 4); i++){
+        in1_rq1 = ((*(target1)) * in1_mul + in1_add) >> in1_shift;
+        in2_rq1 = ((*(target2)) * in2_mul + in2_add) >> in2_shift;
+
+        // SCHEREMO: Maybe it's just LLVM, but unless I hack 3 non-unrolled nops in here, stuff fails
+        #pragma nounroll
+        for (int j = 0; j < 3; j++) {
+    	    asm volatile("nop" ::);
+        }
+
+        target1++;
+        target2++;
+        sum1 = clips8(in1_rq1) + clip8(in2_rq1);
+        if (out_requant_flag) {
+	        sum1 = (sum1 * out_mul + out_add) >> out_shift;
+        }
+
+        out1 = clip8(sum1);
+        *pOutBuffer = (uint8_t)out1;
+        pOutBuffer++;
+    }
    pi_cl_team_barrier(0);
 }

--- a/XpulpV2/32bit/src/Add/pulp_nn_add_u8_i8_i8.c
+++ b/XpulpV2/32bit/src/Add/pulp_nn_add_u8_i8_i8.c
@@ -178,5 +178,27 @@ void __attribute__ ((noinline)) pulp_nn_add_u8_i8_i8(
         *pOutBuffer = (int8_t) out4;
         pOutBuffer++;
     }
+    // SCHEREMO: Cleanup leftovers, not doing it with this codebase for sub-byte formats
+    for (int i=0; i<(((stop-start) * ch_im_out_r * dim_im_in_x) % 4); i++){
+        in1_rq1 = ((*(target1)) * in1_mul + in1_add) >> in1_shift;
+        in2_rq1 = ((*(target2)) * in2_mul + in2_add) >> in2_shift;
+
+        // SCHEREMO: Maybe it's just LLVM, but unless I hack 3 non-unrolled nops in here, stuff fails
+        #pragma nounroll
+        for (int j = 0; j < 3; j++) {
+    	    asm volatile("nop" ::);
+        }
+
+        target1++;
+        target2++;
+        sum1 = clip8(in1_rq1) + clips8(in2_rq1);
+        if (out_requant_flag) {
+	        sum1 = (sum1 * out_mul + out_add) >> out_shift;
+        }
+
+        out1 = clips8(sum1);
+        *pOutBuffer = (int8_t)out1;
+        pOutBuffer++;
+    }
    pi_cl_team_barrier(0);
 }

--- a/XpulpV2/32bit/src/Add/pulp_nn_add_u8_i8_u8.c
+++ b/XpulpV2/32bit/src/Add/pulp_nn_add_u8_i8_u8.c
@@ -178,5 +178,27 @@ void __attribute__ ((noinline)) pulp_nn_add_u8_i8_u8(
         *pOutBuffer = (uint8_t) out4;
         pOutBuffer++;
     }
+    // SCHEREMO: Cleanup leftovers, not doing it with this codebase for sub-byte formats
+    for (int i=0; i<(((stop-start) * ch_im_out_r * dim_im_in_x) % 4); i++){
+        in1_rq1 = ((*(target1)) * in1_mul + in1_add) >> in1_shift;
+        in2_rq1 = ((*(target2)) * in2_mul + in2_add) >> in2_shift;
+
+        // SCHEREMO: Maybe it's just LLVM, but unless I hack 3 non-unrolled nops in here, stuff fails
+        #pragma nounroll
+        for (int j = 0; j < 3; j++) {
+    	    asm volatile("nop" ::);
+        }
+
+        target1++;
+        target2++;
+        sum1 = clip8(in1_rq1) + clips8(in2_rq1);
+        if (out_requant_flag) {
+	        sum1 = (sum1 * out_mul + out_add) >> out_shift;
+        }
+
+        out1 = clip8(sum1);
+        *pOutBuffer = (uint8_t)out1;
+        pOutBuffer++;
+    }
    pi_cl_team_barrier(0);
 }

--- a/XpulpV2/32bit/src/Add/pulp_nn_add_u8_u8_i8.c
+++ b/XpulpV2/32bit/src/Add/pulp_nn_add_u8_u8_i8.c
@@ -178,5 +178,27 @@ void __attribute__ ((noinline)) pulp_nn_add_u8_u8_i8(
         *pOutBuffer = (int8_t) out4;
         pOutBuffer++;
     }
+    // SCHEREMO: Cleanup leftovers, not doing it with this codebase for sub-byte formats
+    for (int i=0; i<(((stop-start) * ch_im_out_r * dim_im_in_x) % 4); i++){
+        in1_rq1 = ((*(target1)) * in1_mul + in1_add) >> in1_shift;
+        in2_rq1 = ((*(target2)) * in2_mul + in2_add) >> in2_shift;
+
+        // SCHEREMO: Maybe it's just LLVM, but unless I hack 3 non-unrolled nops in here, stuff fails
+        #pragma nounroll
+        for (int j = 0; j < 3; j++) {
+    	    asm volatile("nop" ::);
+        }
+
+        target1++;
+        target2++;
+        sum1 = clip8(in1_rq1) + clip8(in2_rq1);
+        if (out_requant_flag) {
+	        sum1 = (sum1 * out_mul + out_add) >> out_shift;
+        }
+
+        out1 = clips8(sum1);
+        *pOutBuffer = (int8_t)out1;
+        pOutBuffer++;
+    }
    pi_cl_team_barrier(0);
 }

--- a/XpulpV2/64bit/include/pulp_nn_utils.h
+++ b/XpulpV2/64bit/include/pulp_nn_utils.h
@@ -29,7 +29,11 @@
 
 #define bitext(x,size,off)                                      __builtin_pulp_bextract(x,size,off)
 #define bitextu(x,size,off)                                     __builtin_pulp_bextractu(x,size,off)
+#ifdef __clang__
+#define bitins(dst,not_mask_imm,src,mask_imm,off)               __builtin_binsert(dst,not_mask_imm,src,mask_imm,off)
+#else
 #define bitins(dst,not_mask_imm,src,mask_imm,off)               __builtin_pulp_binsert(dst,not_mask_imm,src,mask_imm,off)
+#endif
 #define pack(x,y,z,t)                                           __builtin_pulp_pack4(x,y,z,t)
 #define max4(a,b)                                               __builtin_pulp_maxu4(a,b)
 #define maxs4(a, b)                                             __builtin_pulp_max4(a, b)

--- a/XpulpV2/64bit/src/Add/pulp_nn_add_i8_i8_i8.c
+++ b/XpulpV2/64bit/src/Add/pulp_nn_add_i8_i8_i8.c
@@ -178,5 +178,27 @@ void __attribute__ ((noinline)) pulp_nn_add_i8_i8_i8(
         *pOutBuffer = (int8_t) out4;
         pOutBuffer++;
     }
+    // SCHEREMO: Cleanup leftovers, not doing it with this codebase for sub-byte formats
+    for (int i=0; i<(((stop-start) * ch_im_out_r * dim_im_in_x) % 4); i++){
+        in1_rq1 = ((*(target1)) * in1_mul + in1_add) >> in1_shift;
+        in2_rq1 = ((*(target2)) * in2_mul + in2_add) >> in2_shift;
+
+        // SCHEREMO: Maybe it's just LLVM, but unless I hack 3 non-unrolled nops in here, stuff fails
+        #pragma nounroll
+        for (int j = 0; j < 3; j++) {
+    	    asm volatile("nop" ::);
+        }
+
+        target1++;
+        target2++;
+        sum1 = clips8(in1_rq1) + clips8(in2_rq1);
+        if (out_requant_flag) {
+	        sum1 = (sum1 * out_mul + out_add) >> out_shift;
+        }
+
+        out1 = clips8(sum1);
+        *pOutBuffer = (int8_t)out1;
+        pOutBuffer++;
+    }
    pi_cl_team_barrier(0);
 }

--- a/XpulpV2/64bit/src/Add/pulp_nn_add_i8_i8_u8.c
+++ b/XpulpV2/64bit/src/Add/pulp_nn_add_i8_i8_u8.c
@@ -178,5 +178,27 @@ void __attribute__ ((noinline)) pulp_nn_add_i8_i8_u8(
         *pOutBuffer = (uint8_t) out4;
         pOutBuffer++;
     }
+    // SCHEREMO: Cleanup leftovers, not doing it with this codebase for sub-byte formats
+    for (int i=0; i<(((stop-start) * ch_im_out_r * dim_im_in_x) % 4); i++){
+        in1_rq1 = ((*(target1)) * in1_mul + in1_add) >> in1_shift;
+        in2_rq1 = ((*(target2)) * in2_mul + in2_add) >> in2_shift;
+
+        // SCHEREMO: Maybe it's just LLVM, but unless I hack 3 non-unrolled nops in here, stuff fails
+        #pragma nounroll
+        for (int j = 0; j < 3; j++) {
+    	    asm volatile("nop" ::);
+        }
+
+        target1++;
+        target2++;
+        sum1 = clips8(in1_rq1) + clips8(in2_rq1);
+        if (out_requant_flag) {
+	        sum1 = (sum1 * out_mul + out_add) >> out_shift;
+        }
+
+        out1 = clip8(sum1);
+        *pOutBuffer = (uint8_t)out1;
+        pOutBuffer++;
+    }
    pi_cl_team_barrier(0);
 }

--- a/XpulpV2/64bit/src/Add/pulp_nn_add_i8_u8_i8.c
+++ b/XpulpV2/64bit/src/Add/pulp_nn_add_i8_u8_i8.c
@@ -178,5 +178,27 @@ void __attribute__ ((noinline)) pulp_nn_add_i8_u8_i8(
         *pOutBuffer = (int8_t) out4;
         pOutBuffer++;
     }
+    // SCHEREMO: Cleanup leftovers, not doing it with this codebase for sub-byte formats
+    for (int i=0; i<(((stop-start) * ch_im_out_r * dim_im_in_x) % 4); i++){
+        in1_rq1 = ((*(target1)) * in1_mul + in1_add) >> in1_shift;
+        in2_rq1 = ((*(target2)) * in2_mul + in2_add) >> in2_shift;
+
+        // SCHEREMO: Maybe it's just LLVM, but unless I hack 3 non-unrolled nops in here, stuff fails
+        #pragma nounroll
+        for (int j = 0; j < 3; j++) {
+    	    asm volatile("nop" ::);
+        }
+
+        target1++;
+        target2++;
+        sum1 = clips8(in1_rq1) + clip8(in2_rq1);
+        if (out_requant_flag) {
+	        sum1 = (sum1 * out_mul + out_add) >> out_shift;
+        }
+
+        out1 = clips8(sum1);
+        *pOutBuffer = (int8_t)out1;
+        pOutBuffer++;
+    }
    pi_cl_team_barrier(0);
 }

--- a/XpulpV2/64bit/src/Add/pulp_nn_add_i8_u8_u8.c
+++ b/XpulpV2/64bit/src/Add/pulp_nn_add_i8_u8_u8.c
@@ -178,5 +178,27 @@ void __attribute__ ((noinline)) pulp_nn_add_i8_u8_u8(
         *pOutBuffer = (uint8_t) out4;
         pOutBuffer++;
     }
+    // SCHEREMO: Cleanup leftovers, not doing it with this codebase for sub-byte formats
+    for (int i=0; i<(((stop-start) * ch_im_out_r * dim_im_in_x) % 4); i++){
+        in1_rq1 = ((*(target1)) * in1_mul + in1_add) >> in1_shift;
+        in2_rq1 = ((*(target2)) * in2_mul + in2_add) >> in2_shift;
+
+        // SCHEREMO: Maybe it's just LLVM, but unless I hack 3 non-unrolled nops in here, stuff fails
+        #pragma nounroll
+        for (int j = 0; j < 3; j++) {
+    	    asm volatile("nop" ::);
+        }
+
+        target1++;
+        target2++;
+        sum1 = clips8(in1_rq1) + clip8(in2_rq1);
+        if (out_requant_flag) {
+	        sum1 = (sum1 * out_mul + out_add) >> out_shift;
+        }
+
+        out1 = clip8(sum1);
+        *pOutBuffer = (uint8_t)out1;
+        pOutBuffer++;
+    }
    pi_cl_team_barrier(0);
 }

--- a/XpulpV2/64bit/src/Add/pulp_nn_add_u8_i8_i8.c
+++ b/XpulpV2/64bit/src/Add/pulp_nn_add_u8_i8_i8.c
@@ -178,5 +178,27 @@ void __attribute__ ((noinline)) pulp_nn_add_u8_i8_i8(
         *pOutBuffer = (int8_t) out4;
         pOutBuffer++;
     }
+    // SCHEREMO: Cleanup leftovers, not doing it with this codebase for sub-byte formats
+    for (int i=0; i<(((stop-start) * ch_im_out_r * dim_im_in_x) % 4); i++){
+        in1_rq1 = ((*(target1)) * in1_mul + in1_add) >> in1_shift;
+        in2_rq1 = ((*(target2)) * in2_mul + in2_add) >> in2_shift;
+
+        // SCHEREMO: Maybe it's just LLVM, but unless I hack 3 non-unrolled nops in here, stuff fails
+        #pragma nounroll
+        for (int j = 0; j < 3; j++) {
+    	    asm volatile("nop" ::);
+        }
+
+        target1++;
+        target2++;
+        sum1 = clip8(in1_rq1) + clips8(in2_rq1);
+        if (out_requant_flag) {
+	        sum1 = (sum1 * out_mul + out_add) >> out_shift;
+        }
+
+        out1 = clips8(sum1);
+        *pOutBuffer = (int8_t)out1;
+        pOutBuffer++;
+    }
    pi_cl_team_barrier(0);
 }

--- a/XpulpV2/64bit/src/Add/pulp_nn_add_u8_i8_u8.c
+++ b/XpulpV2/64bit/src/Add/pulp_nn_add_u8_i8_u8.c
@@ -178,5 +178,27 @@ void __attribute__ ((noinline)) pulp_nn_add_u8_i8_u8(
         *pOutBuffer = (uint8_t) out4;
         pOutBuffer++;
     }
+    // SCHEREMO: Cleanup leftovers, not doing it with this codebase for sub-byte formats
+    for (int i=0; i<(((stop-start) * ch_im_out_r * dim_im_in_x) % 4); i++){
+        in1_rq1 = ((*(target1)) * in1_mul + in1_add) >> in1_shift;
+        in2_rq1 = ((*(target2)) * in2_mul + in2_add) >> in2_shift;
+
+        // SCHEREMO: Maybe it's just LLVM, but unless I hack 3 non-unrolled nops in here, stuff fails
+        #pragma nounroll
+        for (int j = 0; j < 3; j++) {
+    	    asm volatile("nop" ::);
+        }
+
+        target1++;
+        target2++;
+        sum1 = clip8(in1_rq1) + clips8(in2_rq1);
+        if (out_requant_flag) {
+	        sum1 = (sum1 * out_mul + out_add) >> out_shift;
+        }
+
+        out1 = clip8(sum1);
+        *pOutBuffer = (uint8_t)out1;
+        pOutBuffer++;
+    }
    pi_cl_team_barrier(0);
 }

--- a/XpulpV2/64bit/src/Add/pulp_nn_add_u8_u8_i8.c
+++ b/XpulpV2/64bit/src/Add/pulp_nn_add_u8_u8_i8.c
@@ -178,5 +178,27 @@ void __attribute__ ((noinline)) pulp_nn_add_u8_u8_i8(
         *pOutBuffer = (int8_t) out4;
         pOutBuffer++;
     }
+    // SCHEREMO: Cleanup leftovers, not doing it with this codebase for sub-byte formats
+    for (int i=0; i<(((stop-start) * ch_im_out_r * dim_im_in_x) % 4); i++){
+        in1_rq1 = ((*(target1)) * in1_mul + in1_add) >> in1_shift;
+        in2_rq1 = ((*(target2)) * in2_mul + in2_add) >> in2_shift;
+
+        // SCHEREMO: Maybe it's just LLVM, but unless I hack 3 non-unrolled nops in here, stuff fails
+        #pragma nounroll
+        for (int j = 0; j < 3; j++) {
+    	    asm volatile("nop" ::);
+        }
+
+        target1++;
+        target2++;
+        sum1 = clip8(in1_rq1) + clip8(in2_rq1);
+        if (out_requant_flag) {
+	        sum1 = (sum1 * out_mul + out_add) >> out_shift;
+        }
+
+        out1 = clips8(sum1);
+        *pOutBuffer = (int8_t)out1;
+        pOutBuffer++;
+    }
    pi_cl_team_barrier(0);
 }

--- a/generators/templates/pulp_nn_utils_h.t
+++ b/generators/templates/pulp_nn_utils_h.t
@@ -37,7 +37,11 @@ else:
 
 #define bitext(x,size,off)                                      __builtin_pulp_bextract(x,size,off)
 #define bitextu(x,size,off)                                     __builtin_pulp_bextractu(x,size,off)
+#ifdef __clang__
+#define bitins(dst,not_mask_imm,src,mask_imm,off)               __builtin_binsert(dst,not_mask_imm,src,mask_imm,off)
+#else
 #define bitins(dst,not_mask_imm,src,mask_imm,off)               __builtin_pulp_binsert(dst,not_mask_imm,src,mask_imm,off)
+#endif
 #define pack(x,y,z,t)                                           __builtin_pulp_pack4(x,y,z,t)
 #define max4(a,b)                                               __builtin_pulp_maxu4(a,b)
 #define maxs4(a, b)                                             __builtin_pulp_max4(a, b)


### PR DESCRIPTION
This PR adds support for handing tensors whose length is not divisible by the respective loop unrolling factor.

# Added
* Leftover loop for 8-Bit Add Kernels

# Fixed
* Compile directive in `pulp_nn_utils.h` for LLVM that fixes compilation issue with builtin `bitinsert`s

