### PR TITLE
Fix pulp_zero_mem to avoid illegal HW loop

### DIFF
--- a/XpulpNN-mixed/32bit/include/pulp_nn_utils.h
+++ b/XpulpNN-mixed/32bit/include/pulp_nn_utils.h
@@ -760,7 +760,7 @@ static void __attribute__((noinline)) pulp_zero_mem(uint8_t * pBuffer, unsigned 
   for (int i=0; i<(size>>2); i++)
   {
     *((v4u *)pBuffer) = (v4u){0,0,0,0};
-    MemoryFence();
+    // MemoryFence();
     pBuffer+=4;
   }
   while(lfover)

--- a/XpulpNN-mixed/64bit/include/pulp_nn_utils.h
+++ b/XpulpNN-mixed/64bit/include/pulp_nn_utils.h
@@ -760,7 +760,7 @@ static void __attribute__((noinline)) pulp_zero_mem(uint8_t * pBuffer, unsigned 
   for (int i=0; i<(size>>2); i++)
   {
     *((v4u *)pBuffer) = (v4u){0,0,0,0};
-    MemoryFence();
+    // MemoryFence();
     pBuffer+=4;
   }
   while(lfover)

--- a/XpulpNN/32bit/include/pulp_nn_utils.h
+++ b/XpulpNN/32bit/include/pulp_nn_utils.h
@@ -760,7 +760,7 @@ static void __attribute__((noinline)) pulp_zero_mem(uint8_t * pBuffer, unsigned 
   for (int i=0; i<(size>>2); i++)
   {
     *((v4u *)pBuffer) = (v4u){0,0,0,0};
-    MemoryFence();
+    // MemoryFence();
     pBuffer+=4;
   }
   while(lfover)

--- a/XpulpNN/64bit/include/pulp_nn_utils.h
+++ b/XpulpNN/64bit/include/pulp_nn_utils.h
@@ -760,7 +760,7 @@ static void __attribute__((noinline)) pulp_zero_mem(uint8_t * pBuffer, unsigned 
   for (int i=0; i<(size>>2); i++)
   {
     *((v4u *)pBuffer) = (v4u){0,0,0,0};
-    MemoryFence();
+    // MemoryFence();
     pBuffer+=4;
   }
   while(lfover)

--- a/XpulpV2/32bit/include/pulp_nn_utils.h
+++ b/XpulpV2/32bit/include/pulp_nn_utils.h
@@ -760,7 +760,7 @@ static void __attribute__((noinline)) pulp_zero_mem(uint8_t * pBuffer, unsigned 
   for (int i=0; i<(size>>2); i++)
   {
     *((v4u *)pBuffer) = (v4u){0,0,0,0};
-    MemoryFence();
+    // MemoryFence();
     pBuffer+=4;
   }
   while(lfover)

--- a/XpulpV2/64bit/include/pulp_nn_utils.h
+++ b/XpulpV2/64bit/include/pulp_nn_utils.h
@@ -760,7 +760,7 @@ static void __attribute__((noinline)) pulp_zero_mem(uint8_t * pBuffer, unsigned 
   for (int i=0; i<(size>>2); i++)
   {
     *((v4u *)pBuffer) = (v4u){0,0,0,0};
-    MemoryFence();
+    // MemoryFence();
     pBuffer+=4;
   }
   while(lfover)

--- a/generators/templates/pulp_nn_utils_h.t
+++ b/generators/templates/pulp_nn_utils_h.t
@@ -615,7 +615,7 @@ static void __attribute__((noinline)) pulp_zero_mem(uint8_t * pBuffer, unsigned 
   for (int i=0; i<(size>>2); i++)
   {
     *((v4u *)pBuffer) = (v4u){0,0,0,0};
-    MemoryFence();
+    // MemoryFence();
     pBuffer+=4;
   }
   while(lfover)


### PR DESCRIPTION
[`pulp_zero_mem`](https://github.com/pulp-platform/pulp-nn-mixed/blob/b69ec23ec81595ebbec694f4a28d84022858af83/generators/templates/pulp_nn_utils_h.t#L612) zeros a memory region with the following loop:
```c
  for (int i=0; i<(size>>2); i++) {
    *((v4u *)pBuffer) = (v4u){0,0,0,0};
    MemoryFence();
    pBuffer+=4;
  }
```
This code may be translated into assembly similar to
```assembly
lp.setup  0x0, a1, 0x4
p.sw  a3, 4(a0!)
```
On cores with more than one pipeline stage, this sequence can result in an illegal hardware loop configuration. In particular, one of the [hardware loop constraints](https://docs.openhwgroup.org/projects/cv32e40p-user-manual/en/cv32e40p_v1.3.2/corev_hw_loop.html#hardware-loop-constraints)
 requires the loop body to contain more than one instruction. Additionally, hardware loops do not allow memory ordering instructions (fence, fence.i) in the loop body.

The presence of `MemoryFence()` appears to prevent the compiler from correctly deriving the hardware loop properties, potentially leading to an invalid loop configuration. While this issue does not manifest in GVSoC simulation, it may cause unexpected behavior in RTL simulations.

A potential solution is to remove the `MemoryFence()` from the loop. Doing so allows the compiler to correctly generate a valid hardware loop, typically inserting a `nop` before the store instruction and thus avoiding the illegal configuration.

This PR removes the `MemoryFence()` from the main loop in `pulp_zero_mem` to prevent the generation of illegal hardware loops.
