### PR TITLE
Fix BN-parameter aliasing in leftover-neurons branch of pulp_nn_linear_*

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__/
 test/
 **/gmon.out
+.venv/

--- a/XpulpV2/32bit/src/LinearQuant/pulp_nn_linear_i2_i8_i2.c
+++ b/XpulpV2/32bit/src/LinearQuant/pulp_nn_linear_i2_i8_i2.c
@@ -187,10 +187,10 @@ void pulp_nn_linear_i2_i8_i2(
         }
         if (flag_batch_norm && flag_relu)
         {
-          *pOutBuffer = pulp_nn_bn_quant_i8(sum, *pKappa, *pLambda, out_shift);
+          *pOutBuffer = pulp_nn_bn_quant_i8(sum, *k1, *lambda1, out_shift);
           pOutBuffer++;
-          pKappa++;
-          pLambda++;
+          k1++;
+          lambda1++;
         }
         else
         {

--- a/XpulpV2/32bit/src/LinearQuant/pulp_nn_linear_i2_i8_i4.c
+++ b/XpulpV2/32bit/src/LinearQuant/pulp_nn_linear_i2_i8_i4.c
@@ -196,10 +196,10 @@ void pulp_nn_linear_i2_i8_i4(
         }
         if (flag_batch_norm && flag_relu)
         {
-          *pOutBuffer = pulp_nn_bn_quant_i8(sum, *pKappa, *pLambda, out_shift);
+          *pOutBuffer = pulp_nn_bn_quant_i8(sum, *k1, *lambda1, out_shift);
           pOutBuffer++;
-          pKappa++;
-          pLambda++;
+          k1++;
+          lambda1++;
         }
         else
         {

--- a/XpulpV2/32bit/src/LinearQuant/pulp_nn_linear_i2_i8_i8.c
+++ b/XpulpV2/32bit/src/LinearQuant/pulp_nn_linear_i2_i8_i8.c
@@ -214,10 +214,10 @@ void pulp_nn_linear_i2_i8_i8(
         }
         if (flag_batch_norm && flag_relu)
         {
-          *pOutBuffer = pulp_nn_bn_quant_i8(sum, *pKappa, *pLambda, out_shift);
+          *pOutBuffer = pulp_nn_bn_quant_i8(sum, *k1, *lambda1, out_shift);
           pOutBuffer++;
-          pKappa++;
-          pLambda++;
+          k1++;
+          lambda1++;
         }
         else
         {

--- a/XpulpV2/32bit/src/LinearQuant/pulp_nn_linear_i2_u8_i2.c
+++ b/XpulpV2/32bit/src/LinearQuant/pulp_nn_linear_i2_u8_i2.c
@@ -187,10 +187,10 @@ void pulp_nn_linear_i2_u8_i2(
         }
         if (flag_batch_norm && flag_relu)
         {
-          *pOutBuffer = pulp_nn_bn_quant_u8(sum, *pKappa, *pLambda, out_shift);
+          *pOutBuffer = pulp_nn_bn_quant_u8(sum, *k1, *lambda1, out_shift);
           pOutBuffer++;
-          pKappa++;
-          pLambda++;
+          k1++;
+          lambda1++;
         }
         else
         {

--- a/XpulpV2/32bit/src/LinearQuant/pulp_nn_linear_i2_u8_i4.c
+++ b/XpulpV2/32bit/src/LinearQuant/pulp_nn_linear_i2_u8_i4.c
@@ -196,10 +196,10 @@ void pulp_nn_linear_i2_u8_i4(
         }
         if (flag_batch_norm && flag_relu)
         {
-          *pOutBuffer = pulp_nn_bn_quant_u8(sum, *pKappa, *pLambda, out_shift);
+          *pOutBuffer = pulp_nn_bn_quant_u8(sum, *k1, *lambda1, out_shift);
           pOutBuffer++;
-          pKappa++;
-          pLambda++;
+          k1++;
+          lambda1++;
         }
         else
         {

--- a/XpulpV2/32bit/src/LinearQuant/pulp_nn_linear_i2_u8_i8.c
+++ b/XpulpV2/32bit/src/LinearQuant/pulp_nn_linear_i2_u8_i8.c
@@ -214,10 +214,10 @@ void pulp_nn_linear_i2_u8_i8(
         }
         if (flag_batch_norm && flag_relu)
         {
-          *pOutBuffer = pulp_nn_bn_quant_u8(sum, *pKappa, *pLambda, out_shift);
+          *pOutBuffer = pulp_nn_bn_quant_u8(sum, *k1, *lambda1, out_shift);
           pOutBuffer++;
-          pKappa++;
-          pLambda++;
+          k1++;
+          lambda1++;
         }
         else
         {

--- a/XpulpV2/32bit/src/LinearQuant/pulp_nn_linear_i4_i8_i2.c
+++ b/XpulpV2/32bit/src/LinearQuant/pulp_nn_linear_i4_i8_i2.c
@@ -188,10 +188,10 @@ void pulp_nn_linear_i4_i8_i2(
         }
         if (flag_batch_norm && flag_relu)
         {
-          *pOutBuffer = pulp_nn_bn_quant_i8(sum, *pKappa, *pLambda, out_shift);
+          *pOutBuffer = pulp_nn_bn_quant_i8(sum, *k1, *lambda1, out_shift);
           pOutBuffer++;
-          pKappa++;
-          pLambda++;
+          k1++;
+          lambda1++;
         }
         else
         {

--- a/XpulpV2/32bit/src/LinearQuant/pulp_nn_linear_i4_i8_i4.c
+++ b/XpulpV2/32bit/src/LinearQuant/pulp_nn_linear_i4_i8_i4.c
@@ -165,10 +165,10 @@ void pulp_nn_linear_i4_i8_i4(
         }
         if (flag_batch_norm && flag_relu)
         {
-          *pOutBuffer = pulp_nn_bn_quant_i8(sum, *pKappa, *pLambda, out_shift);
+          *pOutBuffer = pulp_nn_bn_quant_i8(sum, *k1, *lambda1, out_shift);
           pOutBuffer++;
-          pKappa++;
-          pLambda++;
+          k1++;
+          lambda1++;
         }
         else
         {

--- a/XpulpV2/32bit/src/LinearQuant/pulp_nn_linear_i4_i8_i8.c
+++ b/XpulpV2/32bit/src/LinearQuant/pulp_nn_linear_i4_i8_i8.c
@@ -174,10 +174,10 @@ void pulp_nn_linear_i4_i8_i8(
         }
         if (flag_batch_norm && flag_relu)
         {
-          *pOutBuffer = pulp_nn_bn_quant_i8(sum, *pKappa, *pLambda, out_shift);
+          *pOutBuffer = pulp_nn_bn_quant_i8(sum, *k1, *lambda1, out_shift);
           pOutBuffer++;
-          pKappa++;
-          pLambda++;
+          k1++;
+          lambda1++;
         }
         else
         {

--- a/XpulpV2/32bit/src/LinearQuant/pulp_nn_linear_i4_u8_i2.c
+++ b/XpulpV2/32bit/src/LinearQuant/pulp_nn_linear_i4_u8_i2.c
@@ -188,10 +188,10 @@ void pulp_nn_linear_i4_u8_i2(
         }
         if (flag_batch_norm && flag_relu)
         {
-          *pOutBuffer = pulp_nn_bn_quant_u8(sum, *pKappa, *pLambda, out_shift);
+          *pOutBuffer = pulp_nn_bn_quant_u8(sum, *k1, *lambda1, out_shift);
           pOutBuffer++;
-          pKappa++;
-          pLambda++;
+          k1++;
+          lambda1++;
         }
         else
         {

--- a/XpulpV2/32bit/src/LinearQuant/pulp_nn_linear_i4_u8_i4.c
+++ b/XpulpV2/32bit/src/LinearQuant/pulp_nn_linear_i4_u8_i4.c
@@ -165,10 +165,10 @@ void pulp_nn_linear_i4_u8_i4(
         }
         if (flag_batch_norm && flag_relu)
         {
-          *pOutBuffer = pulp_nn_bn_quant_u8(sum, *pKappa, *pLambda, out_shift);
+          *pOutBuffer = pulp_nn_bn_quant_u8(sum, *k1, *lambda1, out_shift);
           pOutBuffer++;
-          pKappa++;
-          pLambda++;
+          k1++;
+          lambda1++;
         }
         else
         {

--- a/XpulpV2/32bit/src/LinearQuant/pulp_nn_linear_i4_u8_i8.c
+++ b/XpulpV2/32bit/src/LinearQuant/pulp_nn_linear_i4_u8_i8.c
@@ -174,10 +174,10 @@ void pulp_nn_linear_i4_u8_i8(
         }
         if (flag_batch_norm && flag_relu)
         {
-          *pOutBuffer = pulp_nn_bn_quant_u8(sum, *pKappa, *pLambda, out_shift);
+          *pOutBuffer = pulp_nn_bn_quant_u8(sum, *k1, *lambda1, out_shift);
           pOutBuffer++;
-          pKappa++;
-          pLambda++;
+          k1++;
+          lambda1++;
         }
         else
         {

--- a/XpulpV2/32bit/src/LinearQuant/pulp_nn_linear_i8_i8_i2.c
+++ b/XpulpV2/32bit/src/LinearQuant/pulp_nn_linear_i8_i8_i2.c
@@ -200,10 +200,10 @@ void pulp_nn_linear_i8_i8_i2(
         }
         if (flag_batch_norm && flag_relu)
         {
-          *pOutBuffer = pulp_nn_bn_quant_i8(sum, *pKappa, *pLambda, out_shift);
+          *pOutBuffer = pulp_nn_bn_quant_i8(sum, *k1, *lambda1, out_shift);
           pOutBuffer++;
-          pKappa++;
-          pLambda++;
+          k1++;
+          lambda1++;
         }
         else
         {

--- a/XpulpV2/32bit/src/LinearQuant/pulp_nn_linear_i8_i8_i4.c
+++ b/XpulpV2/32bit/src/LinearQuant/pulp_nn_linear_i8_i8_i4.c
@@ -171,10 +171,10 @@ void pulp_nn_linear_i8_i8_i4(
         }
         if (flag_batch_norm && flag_relu)
         {
-          *pOutBuffer = pulp_nn_bn_quant_i8(sum, *pKappa, *pLambda, out_shift);
+          *pOutBuffer = pulp_nn_bn_quant_i8(sum, *k1, *lambda1, out_shift);
           pOutBuffer++;
-          pKappa++;
-          pLambda++;
+          k1++;
+          lambda1++;
         }
         else
         {

--- a/XpulpV2/32bit/src/LinearQuant/pulp_nn_linear_i8_i8_i8.c
+++ b/XpulpV2/32bit/src/LinearQuant/pulp_nn_linear_i8_i8_i8.c
@@ -154,10 +154,10 @@ void pulp_nn_linear_i8_i8_i8(
         }
         if (flag_batch_norm && flag_relu)
         {
-          *pOutBuffer = pulp_nn_bn_quant_i8(sum, *pKappa, *pLambda, out_shift);
+          *pOutBuffer = pulp_nn_bn_quant_i8(sum, *k1, *lambda1, out_shift);
           pOutBuffer++;
-          pKappa++;
-          pLambda++;
+          k1++;
+          lambda1++;
         }
         else
         {

--- a/XpulpV2/32bit/src/LinearQuant/pulp_nn_linear_i8_u8_i2.c
+++ b/XpulpV2/32bit/src/LinearQuant/pulp_nn_linear_i8_u8_i2.c
@@ -200,10 +200,10 @@ void pulp_nn_linear_i8_u8_i2(
         }
         if (flag_batch_norm && flag_relu)
         {
-          *pOutBuffer = pulp_nn_bn_quant_u8(sum, *pKappa, *pLambda, out_shift);
+          *pOutBuffer = pulp_nn_bn_quant_u8(sum, *k1, *lambda1, out_shift);
           pOutBuffer++;
-          pKappa++;
-          pLambda++;
+          k1++;
+          lambda1++;
         }
         else
         {

--- a/XpulpV2/32bit/src/LinearQuant/pulp_nn_linear_i8_u8_i4.c
+++ b/XpulpV2/32bit/src/LinearQuant/pulp_nn_linear_i8_u8_i4.c
@@ -171,10 +171,10 @@ void pulp_nn_linear_i8_u8_i4(
         }
         if (flag_batch_norm && flag_relu)
         {
-          *pOutBuffer = pulp_nn_bn_quant_u8(sum, *pKappa, *pLambda, out_shift);
+          *pOutBuffer = pulp_nn_bn_quant_u8(sum, *k1, *lambda1, out_shift);
           pOutBuffer++;
-          pKappa++;
-          pLambda++;
+          k1++;
+          lambda1++;
         }
         else
         {

--- a/XpulpV2/32bit/src/LinearQuant/pulp_nn_linear_i8_u8_i8.c
+++ b/XpulpV2/32bit/src/LinearQuant/pulp_nn_linear_i8_u8_i8.c
@@ -154,10 +154,10 @@ void pulp_nn_linear_i8_u8_i8(
         }
         if (flag_batch_norm && flag_relu)
         {
-          *pOutBuffer = pulp_nn_bn_quant_u8(sum, *pKappa, *pLambda, out_shift);
+          *pOutBuffer = pulp_nn_bn_quant_u8(sum, *k1, *lambda1, out_shift);
           pOutBuffer++;
-          pKappa++;
-          pLambda++;
+          k1++;
+          lambda1++;
         }
         else
         {

--- a/XpulpV2/32bit/src/LinearQuant/pulp_nn_linear_u2_i8_i2.c
+++ b/XpulpV2/32bit/src/LinearQuant/pulp_nn_linear_u2_i8_i2.c
@@ -187,10 +187,10 @@ void pulp_nn_linear_u2_i8_i2(
         }
         if (flag_batch_norm && flag_relu)
         {
-          *pOutBuffer = pulp_nn_bn_quant_i8(sum, *pKappa, *pLambda, out_shift);
+          *pOutBuffer = pulp_nn_bn_quant_i8(sum, *k1, *lambda1, out_shift);
           pOutBuffer++;
-          pKappa++;
-          pLambda++;
+          k1++;
+          lambda1++;
         }
         else
         {

--- a/XpulpV2/32bit/src/LinearQuant/pulp_nn_linear_u2_i8_i4.c
+++ b/XpulpV2/32bit/src/LinearQuant/pulp_nn_linear_u2_i8_i4.c
@@ -196,10 +196,10 @@ void pulp_nn_linear_u2_i8_i4(
         }
         if (flag_batch_norm && flag_relu)
         {
-          *pOutBuffer = pulp_nn_bn_quant_i8(sum, *pKappa, *pLambda, out_shift);
+          *pOutBuffer = pulp_nn_bn_quant_i8(sum, *k1, *lambda1, out_shift);
           pOutBuffer++;
-          pKappa++;
-          pLambda++;
+          k1++;
+          lambda1++;
         }
         else
         {

--- a/XpulpV2/32bit/src/LinearQuant/pulp_nn_linear_u2_i8_i8.c
+++ b/XpulpV2/32bit/src/LinearQuant/pulp_nn_linear_u2_i8_i8.c
@@ -214,10 +214,10 @@ void pulp_nn_linear_u2_i8_i8(
         }
         if (flag_batch_norm && flag_relu)
         {
-          *pOutBuffer = pulp_nn_bn_quant_i8(sum, *pKappa, *pLambda, out_shift);
+          *pOutBuffer = pulp_nn_bn_quant_i8(sum, *k1, *lambda1, out_shift);
           pOutBuffer++;
-          pKappa++;
-          pLambda++;
+          k1++;
+          lambda1++;
         }
         else
         {

--- a/XpulpV2/32bit/src/LinearQuant/pulp_nn_linear_u2_u8_i2.c
+++ b/XpulpV2/32bit/src/LinearQuant/pulp_nn_linear_u2_u8_i2.c
@@ -187,10 +187,10 @@ void pulp_nn_linear_u2_u8_i2(
         }
         if (flag_batch_norm && flag_relu)
         {
-          *pOutBuffer = pulp_nn_bn_quant_u8(sum, *pKappa, *pLambda, out_shift);
+          *pOutBuffer = pulp_nn_bn_quant_u8(sum, *k1, *lambda1, out_shift);
           pOutBuffer++;
-          pKappa++;
-          pLambda++;
+          k1++;
+          lambda1++;
         }
         else
         {

--- a/XpulpV2/32bit/src/LinearQuant/pulp_nn_linear_u2_u8_i4.c
+++ b/XpulpV2/32bit/src/LinearQuant/pulp_nn_linear_u2_u8_i4.c
@@ -196,10 +196,10 @@ void pulp_nn_linear_u2_u8_i4(
         }
         if (flag_batch_norm && flag_relu)
         {
-          *pOutBuffer = pulp_nn_bn_quant_u8(sum, *pKappa, *pLambda, out_shift);
+          *pOutBuffer = pulp_nn_bn_quant_u8(sum, *k1, *lambda1, out_shift);
           pOutBuffer++;
-          pKappa++;
-          pLambda++;
+          k1++;
+          lambda1++;
         }
         else
         {

--- a/XpulpV2/32bit/src/LinearQuant/pulp_nn_linear_u2_u8_i8.c
+++ b/XpulpV2/32bit/src/LinearQuant/pulp_nn_linear_u2_u8_i8.c
@@ -214,10 +214,10 @@ void pulp_nn_linear_u2_u8_i8(
         }
         if (flag_batch_norm && flag_relu)
         {
-          *pOutBuffer = pulp_nn_bn_quant_u8(sum, *pKappa, *pLambda, out_shift);
+          *pOutBuffer = pulp_nn_bn_quant_u8(sum, *k1, *lambda1, out_shift);
           pOutBuffer++;
-          pKappa++;
-          pLambda++;
+          k1++;
+          lambda1++;
         }
         else
         {

--- a/XpulpV2/32bit/src/LinearQuant/pulp_nn_linear_u4_i8_i2.c
+++ b/XpulpV2/32bit/src/LinearQuant/pulp_nn_linear_u4_i8_i2.c
@@ -188,10 +188,10 @@ void pulp_nn_linear_u4_i8_i2(
         }
         if (flag_batch_norm && flag_relu)
         {
-          *pOutBuffer = pulp_nn_bn_quant_i8(sum, *pKappa, *pLambda, out_shift);
+          *pOutBuffer = pulp_nn_bn_quant_i8(sum, *k1, *lambda1, out_shift);
           pOutBuffer++;
-          pKappa++;
-          pLambda++;
+          k1++;
+          lambda1++;
         }
         else
         {

--- a/XpulpV2/32bit/src/LinearQuant/pulp_nn_linear_u4_i8_i4.c
+++ b/XpulpV2/32bit/src/LinearQuant/pulp_nn_linear_u4_i8_i4.c
@@ -165,10 +165,10 @@ void pulp_nn_linear_u4_i8_i4(
         }
         if (flag_batch_norm && flag_relu)
         {
-          *pOutBuffer = pulp_nn_bn_quant_i8(sum, *pKappa, *pLambda, out_shift);
+          *pOutBuffer = pulp_nn_bn_quant_i8(sum, *k1, *lambda1, out_shift);
           pOutBuffer++;
-          pKappa++;
-          pLambda++;
+          k1++;
+          lambda1++;
         }
         else
         {

--- a/XpulpV2/32bit/src/LinearQuant/pulp_nn_linear_u4_i8_i8.c
+++ b/XpulpV2/32bit/src/LinearQuant/pulp_nn_linear_u4_i8_i8.c
@@ -174,10 +174,10 @@ void pulp_nn_linear_u4_i8_i8(
         }
         if (flag_batch_norm && flag_relu)
         {
-          *pOutBuffer = pulp_nn_bn_quant_i8(sum, *pKappa, *pLambda, out_shift);
+          *pOutBuffer = pulp_nn_bn_quant_i8(sum, *k1, *lambda1, out_shift);
           pOutBuffer++;
-          pKappa++;
-          pLambda++;
+          k1++;
+          lambda1++;
         }
         else
         {

--- a/XpulpV2/32bit/src/LinearQuant/pulp_nn_linear_u4_u8_i2.c
+++ b/XpulpV2/32bit/src/LinearQuant/pulp_nn_linear_u4_u8_i2.c
@@ -188,10 +188,10 @@ void pulp_nn_linear_u4_u8_i2(
         }
         if (flag_batch_norm && flag_relu)
         {
-          *pOutBuffer = pulp_nn_bn_quant_u8(sum, *pKappa, *pLambda, out_shift);
+          *pOutBuffer = pulp_nn_bn_quant_u8(sum, *k1, *lambda1, out_shift);
           pOutBuffer++;
-          pKappa++;
-          pLambda++;
+          k1++;
+          lambda1++;
         }
         else
         {

--- a/XpulpV2/32bit/src/LinearQuant/pulp_nn_linear_u4_u8_i4.c
+++ b/XpulpV2/32bit/src/LinearQuant/pulp_nn_linear_u4_u8_i4.c
@@ -165,10 +165,10 @@ void pulp_nn_linear_u4_u8_i4(
         }
         if (flag_batch_norm && flag_relu)
         {
-          *pOutBuffer = pulp_nn_bn_quant_u8(sum, *pKappa, *pLambda, out_shift);
+          *pOutBuffer = pulp_nn_bn_quant_u8(sum, *k1, *lambda1, out_shift);
           pOutBuffer++;
-          pKappa++;
-          pLambda++;
+          k1++;
+          lambda1++;
         }
         else
         {

--- a/XpulpV2/32bit/src/LinearQuant/pulp_nn_linear_u4_u8_i8.c
+++ b/XpulpV2/32bit/src/LinearQuant/pulp_nn_linear_u4_u8_i8.c
@@ -174,10 +174,10 @@ void pulp_nn_linear_u4_u8_i8(
         }
         if (flag_batch_norm && flag_relu)
         {
-          *pOutBuffer = pulp_nn_bn_quant_u8(sum, *pKappa, *pLambda, out_shift);
+          *pOutBuffer = pulp_nn_bn_quant_u8(sum, *k1, *lambda1, out_shift);
           pOutBuffer++;
-          pKappa++;
-          pLambda++;
+          k1++;
+          lambda1++;
         }
         else
         {

--- a/XpulpV2/32bit/src/LinearQuant/pulp_nn_linear_u8_i8_i2.c
+++ b/XpulpV2/32bit/src/LinearQuant/pulp_nn_linear_u8_i8_i2.c
@@ -200,10 +200,10 @@ void pulp_nn_linear_u8_i8_i2(
         }
         if (flag_batch_norm && flag_relu)
         {
-          *pOutBuffer = pulp_nn_bn_quant_i8(sum, *pKappa, *pLambda, out_shift);
+          *pOutBuffer = pulp_nn_bn_quant_i8(sum, *k1, *lambda1, out_shift);
           pOutBuffer++;
-          pKappa++;
-          pLambda++;
+          k1++;
+          lambda1++;
         }
         else
         {

--- a/XpulpV2/32bit/src/LinearQuant/pulp_nn_linear_u8_i8_i4.c
+++ b/XpulpV2/32bit/src/LinearQuant/pulp_nn_linear_u8_i8_i4.c
@@ -171,10 +171,10 @@ void pulp_nn_linear_u8_i8_i4(
         }
         if (flag_batch_norm && flag_relu)
         {
-          *pOutBuffer = pulp_nn_bn_quant_i8(sum, *pKappa, *pLambda, out_shift);
+          *pOutBuffer = pulp_nn_bn_quant_i8(sum, *k1, *lambda1, out_shift);
           pOutBuffer++;
-          pKappa++;
-          pLambda++;
+          k1++;
+          lambda1++;
         }
         else
         {

--- a/XpulpV2/32bit/src/LinearQuant/pulp_nn_linear_u8_i8_i8.c
+++ b/XpulpV2/32bit/src/LinearQuant/pulp_nn_linear_u8_i8_i8.c
@@ -154,10 +154,10 @@ void pulp_nn_linear_u8_i8_i8(
         }
         if (flag_batch_norm && flag_relu)
         {
-          *pOutBuffer = pulp_nn_bn_quant_i8(sum, *pKappa, *pLambda, out_shift);
+          *pOutBuffer = pulp_nn_bn_quant_i8(sum, *k1, *lambda1, out_shift);
           pOutBuffer++;
-          pKappa++;
-          pLambda++;
+          k1++;
+          lambda1++;
         }
         else
         {

--- a/XpulpV2/32bit/src/LinearQuant/pulp_nn_linear_u8_u8_i2.c
+++ b/XpulpV2/32bit/src/LinearQuant/pulp_nn_linear_u8_u8_i2.c
@@ -200,10 +200,10 @@ void pulp_nn_linear_u8_u8_i2(
         }
         if (flag_batch_norm && flag_relu)
         {
-          *pOutBuffer = pulp_nn_bn_quant_u8(sum, *pKappa, *pLambda, out_shift);
+          *pOutBuffer = pulp_nn_bn_quant_u8(sum, *k1, *lambda1, out_shift);
           pOutBuffer++;
-          pKappa++;
-          pLambda++;
+          k1++;
+          lambda1++;
         }
         else
         {

--- a/XpulpV2/32bit/src/LinearQuant/pulp_nn_linear_u8_u8_i4.c
+++ b/XpulpV2/32bit/src/LinearQuant/pulp_nn_linear_u8_u8_i4.c
@@ -171,10 +171,10 @@ void pulp_nn_linear_u8_u8_i4(
         }
         if (flag_batch_norm && flag_relu)
         {
-          *pOutBuffer = pulp_nn_bn_quant_u8(sum, *pKappa, *pLambda, out_shift);
+          *pOutBuffer = pulp_nn_bn_quant_u8(sum, *k1, *lambda1, out_shift);
           pOutBuffer++;
-          pKappa++;
-          pLambda++;
+          k1++;
+          lambda1++;
         }
         else
         {

--- a/XpulpV2/32bit/src/LinearQuant/pulp_nn_linear_u8_u8_i8.c
+++ b/XpulpV2/32bit/src/LinearQuant/pulp_nn_linear_u8_u8_i8.c
@@ -154,10 +154,10 @@ void pulp_nn_linear_u8_u8_i8(
         }
         if (flag_batch_norm && flag_relu)
         {
-          *pOutBuffer = pulp_nn_bn_quant_u8(sum, *pKappa, *pLambda, out_shift);
+          *pOutBuffer = pulp_nn_bn_quant_u8(sum, *k1, *lambda1, out_shift);
           pOutBuffer++;
-          pKappa++;
-          pLambda++;
+          k1++;
+          lambda1++;
         }
         else
         {

--- a/XpulpV2/64bit/src/LinearQuant/pulp_nn_linear_i2_i8_i2.c
+++ b/XpulpV2/64bit/src/LinearQuant/pulp_nn_linear_i2_i8_i2.c
@@ -187,10 +187,10 @@ void pulp_nn_linear_i2_i8_i2(
         }
         if (flag_batch_norm && flag_relu)
         {
-          *pOutBuffer = pulp_nn_bn_quant_i8(sum, *pKappa, *pLambda, out_shift);
+          *pOutBuffer = pulp_nn_bn_quant_i8(sum, *k1, *lambda1, out_shift);
           pOutBuffer++;
-          pKappa++;
-          pLambda++;
+          k1++;
+          lambda1++;
         }
         else
         {

--- a/XpulpV2/64bit/src/LinearQuant/pulp_nn_linear_i2_i8_i4.c
+++ b/XpulpV2/64bit/src/LinearQuant/pulp_nn_linear_i2_i8_i4.c
@@ -196,10 +196,10 @@ void pulp_nn_linear_i2_i8_i4(
         }
         if (flag_batch_norm && flag_relu)
         {
-          *pOutBuffer = pulp_nn_bn_quant_i8(sum, *pKappa, *pLambda, out_shift);
+          *pOutBuffer = pulp_nn_bn_quant_i8(sum, *k1, *lambda1, out_shift);
           pOutBuffer++;
-          pKappa++;
-          pLambda++;
+          k1++;
+          lambda1++;
         }
         else
         {

--- a/XpulpV2/64bit/src/LinearQuant/pulp_nn_linear_i2_i8_i8.c
+++ b/XpulpV2/64bit/src/LinearQuant/pulp_nn_linear_i2_i8_i8.c
@@ -214,10 +214,10 @@ void pulp_nn_linear_i2_i8_i8(
         }
         if (flag_batch_norm && flag_relu)
         {
-          *pOutBuffer = pulp_nn_bn_quant_i8(sum, *pKappa, *pLambda, out_shift);
+          *pOutBuffer = pulp_nn_bn_quant_i8(sum, *k1, *lambda1, out_shift);
           pOutBuffer++;
-          pKappa++;
-          pLambda++;
+          k1++;
+          lambda1++;
         }
         else
         {

--- a/XpulpV2/64bit/src/LinearQuant/pulp_nn_linear_i2_u8_i2.c
+++ b/XpulpV2/64bit/src/LinearQuant/pulp_nn_linear_i2_u8_i2.c
@@ -187,10 +187,10 @@ void pulp_nn_linear_i2_u8_i2(
         }
         if (flag_batch_norm && flag_relu)
         {
-          *pOutBuffer = pulp_nn_bn_quant_u8(sum, *pKappa, *pLambda, out_shift);
+          *pOutBuffer = pulp_nn_bn_quant_u8(sum, *k1, *lambda1, out_shift);
           pOutBuffer++;
-          pKappa++;
-          pLambda++;
+          k1++;
+          lambda1++;
         }
         else
         {

--- a/XpulpV2/64bit/src/LinearQuant/pulp_nn_linear_i2_u8_i4.c
+++ b/XpulpV2/64bit/src/LinearQuant/pulp_nn_linear_i2_u8_i4.c
@@ -196,10 +196,10 @@ void pulp_nn_linear_i2_u8_i4(
         }
         if (flag_batch_norm && flag_relu)
         {
-          *pOutBuffer = pulp_nn_bn_quant_u8(sum, *pKappa, *pLambda, out_shift);
+          *pOutBuffer = pulp_nn_bn_quant_u8(sum, *k1, *lambda1, out_shift);
           pOutBuffer++;
-          pKappa++;
-          pLambda++;
+          k1++;
+          lambda1++;
         }
         else
         {

--- a/XpulpV2/64bit/src/LinearQuant/pulp_nn_linear_i2_u8_i8.c
+++ b/XpulpV2/64bit/src/LinearQuant/pulp_nn_linear_i2_u8_i8.c
@@ -214,10 +214,10 @@ void pulp_nn_linear_i2_u8_i8(
         }
         if (flag_batch_norm && flag_relu)
         {
-          *pOutBuffer = pulp_nn_bn_quant_u8(sum, *pKappa, *pLambda, out_shift);
+          *pOutBuffer = pulp_nn_bn_quant_u8(sum, *k1, *lambda1, out_shift);
           pOutBuffer++;
-          pKappa++;
-          pLambda++;
+          k1++;
+          lambda1++;
         }
         else
         {

--- a/XpulpV2/64bit/src/LinearQuant/pulp_nn_linear_i4_i8_i2.c
+++ b/XpulpV2/64bit/src/LinearQuant/pulp_nn_linear_i4_i8_i2.c
@@ -188,10 +188,10 @@ void pulp_nn_linear_i4_i8_i2(
         }
         if (flag_batch_norm && flag_relu)
         {
-          *pOutBuffer = pulp_nn_bn_quant_i8(sum, *pKappa, *pLambda, out_shift);
+          *pOutBuffer = pulp_nn_bn_quant_i8(sum, *k1, *lambda1, out_shift);
           pOutBuffer++;
-          pKappa++;
-          pLambda++;
+          k1++;
+          lambda1++;
         }
         else
         {

--- a/XpulpV2/64bit/src/LinearQuant/pulp_nn_linear_i4_i8_i4.c
+++ b/XpulpV2/64bit/src/LinearQuant/pulp_nn_linear_i4_i8_i4.c
@@ -165,10 +165,10 @@ void pulp_nn_linear_i4_i8_i4(
         }
         if (flag_batch_norm && flag_relu)
         {
-          *pOutBuffer = pulp_nn_bn_quant_i8(sum, *pKappa, *pLambda, out_shift);
+          *pOutBuffer = pulp_nn_bn_quant_i8(sum, *k1, *lambda1, out_shift);
           pOutBuffer++;
-          pKappa++;
-          pLambda++;
+          k1++;
+          lambda1++;
         }
         else
         {

--- a/XpulpV2/64bit/src/LinearQuant/pulp_nn_linear_i4_i8_i8.c
+++ b/XpulpV2/64bit/src/LinearQuant/pulp_nn_linear_i4_i8_i8.c
@@ -174,10 +174,10 @@ void pulp_nn_linear_i4_i8_i8(
         }
         if (flag_batch_norm && flag_relu)
         {
-          *pOutBuffer = pulp_nn_bn_quant_i8(sum, *pKappa, *pLambda, out_shift);
+          *pOutBuffer = pulp_nn_bn_quant_i8(sum, *k1, *lambda1, out_shift);
           pOutBuffer++;
-          pKappa++;
-          pLambda++;
+          k1++;
+          lambda1++;
         }
         else
         {

--- a/XpulpV2/64bit/src/LinearQuant/pulp_nn_linear_i4_u8_i2.c
+++ b/XpulpV2/64bit/src/LinearQuant/pulp_nn_linear_i4_u8_i2.c
@@ -188,10 +188,10 @@ void pulp_nn_linear_i4_u8_i2(
         }
         if (flag_batch_norm && flag_relu)
         {
-          *pOutBuffer = pulp_nn_bn_quant_u8(sum, *pKappa, *pLambda, out_shift);
+          *pOutBuffer = pulp_nn_bn_quant_u8(sum, *k1, *lambda1, out_shift);
           pOutBuffer++;
-          pKappa++;
-          pLambda++;
+          k1++;
+          lambda1++;
         }
         else
         {

--- a/XpulpV2/64bit/src/LinearQuant/pulp_nn_linear_i4_u8_i4.c
+++ b/XpulpV2/64bit/src/LinearQuant/pulp_nn_linear_i4_u8_i4.c
@@ -165,10 +165,10 @@ void pulp_nn_linear_i4_u8_i4(
         }
         if (flag_batch_norm && flag_relu)
         {
-          *pOutBuffer = pulp_nn_bn_quant_u8(sum, *pKappa, *pLambda, out_shift);
+          *pOutBuffer = pulp_nn_bn_quant_u8(sum, *k1, *lambda1, out_shift);
           pOutBuffer++;
-          pKappa++;
-          pLambda++;
+          k1++;
+          lambda1++;
         }
         else
         {

--- a/XpulpV2/64bit/src/LinearQuant/pulp_nn_linear_i4_u8_i8.c
+++ b/XpulpV2/64bit/src/LinearQuant/pulp_nn_linear_i4_u8_i8.c
@@ -174,10 +174,10 @@ void pulp_nn_linear_i4_u8_i8(
         }
         if (flag_batch_norm && flag_relu)
         {
-          *pOutBuffer = pulp_nn_bn_quant_u8(sum, *pKappa, *pLambda, out_shift);
+          *pOutBuffer = pulp_nn_bn_quant_u8(sum, *k1, *lambda1, out_shift);
           pOutBuffer++;
-          pKappa++;
-          pLambda++;
+          k1++;
+          lambda1++;
         }
         else
         {

--- a/XpulpV2/64bit/src/LinearQuant/pulp_nn_linear_i8_i8_i2.c
+++ b/XpulpV2/64bit/src/LinearQuant/pulp_nn_linear_i8_i8_i2.c
@@ -200,10 +200,10 @@ void pulp_nn_linear_i8_i8_i2(
         }
         if (flag_batch_norm && flag_relu)
         {
-          *pOutBuffer = pulp_nn_bn_quant_i8(sum, *pKappa, *pLambda, out_shift);
+          *pOutBuffer = pulp_nn_bn_quant_i8(sum, *k1, *lambda1, out_shift);
           pOutBuffer++;
-          pKappa++;
-          pLambda++;
+          k1++;
+          lambda1++;
         }
         else
         {

--- a/XpulpV2/64bit/src/LinearQuant/pulp_nn_linear_i8_i8_i4.c
+++ b/XpulpV2/64bit/src/LinearQuant/pulp_nn_linear_i8_i8_i4.c
@@ -171,10 +171,10 @@ void pulp_nn_linear_i8_i8_i4(
         }
         if (flag_batch_norm && flag_relu)
         {
-          *pOutBuffer = pulp_nn_bn_quant_i8(sum, *pKappa, *pLambda, out_shift);
+          *pOutBuffer = pulp_nn_bn_quant_i8(sum, *k1, *lambda1, out_shift);
           pOutBuffer++;
-          pKappa++;
-          pLambda++;
+          k1++;
+          lambda1++;
         }
         else
         {

--- a/XpulpV2/64bit/src/LinearQuant/pulp_nn_linear_i8_i8_i8.c
+++ b/XpulpV2/64bit/src/LinearQuant/pulp_nn_linear_i8_i8_i8.c
@@ -154,10 +154,10 @@ void pulp_nn_linear_i8_i8_i8(
         }
         if (flag_batch_norm && flag_relu)
         {
-          *pOutBuffer = pulp_nn_bn_quant_i8(sum, *pKappa, *pLambda, out_shift);
+          *pOutBuffer = pulp_nn_bn_quant_i8(sum, *k1, *lambda1, out_shift);
           pOutBuffer++;
-          pKappa++;
-          pLambda++;
+          k1++;
+          lambda1++;
         }
         else
         {

--- a/XpulpV2/64bit/src/LinearQuant/pulp_nn_linear_i8_u8_i2.c
+++ b/XpulpV2/64bit/src/LinearQuant/pulp_nn_linear_i8_u8_i2.c
@@ -200,10 +200,10 @@ void pulp_nn_linear_i8_u8_i2(
         }
         if (flag_batch_norm && flag_relu)
         {
-          *pOutBuffer = pulp_nn_bn_quant_u8(sum, *pKappa, *pLambda, out_shift);
+          *pOutBuffer = pulp_nn_bn_quant_u8(sum, *k1, *lambda1, out_shift);
           pOutBuffer++;
-          pKappa++;
-          pLambda++;
+          k1++;
+          lambda1++;
         }
         else
         {

--- a/XpulpV2/64bit/src/LinearQuant/pulp_nn_linear_i8_u8_i4.c
+++ b/XpulpV2/64bit/src/LinearQuant/pulp_nn_linear_i8_u8_i4.c
@@ -171,10 +171,10 @@ void pulp_nn_linear_i8_u8_i4(
         }
         if (flag_batch_norm && flag_relu)
         {
-          *pOutBuffer = pulp_nn_bn_quant_u8(sum, *pKappa, *pLambda, out_shift);
+          *pOutBuffer = pulp_nn_bn_quant_u8(sum, *k1, *lambda1, out_shift);
           pOutBuffer++;
-          pKappa++;
-          pLambda++;
+          k1++;
+          lambda1++;
         }
         else
         {

--- a/XpulpV2/64bit/src/LinearQuant/pulp_nn_linear_i8_u8_i8.c
+++ b/XpulpV2/64bit/src/LinearQuant/pulp_nn_linear_i8_u8_i8.c
@@ -154,10 +154,10 @@ void pulp_nn_linear_i8_u8_i8(
         }
         if (flag_batch_norm && flag_relu)
         {
-          *pOutBuffer = pulp_nn_bn_quant_u8(sum, *pKappa, *pLambda, out_shift);
+          *pOutBuffer = pulp_nn_bn_quant_u8(sum, *k1, *lambda1, out_shift);
           pOutBuffer++;
-          pKappa++;
-          pLambda++;
+          k1++;
+          lambda1++;
         }
         else
         {

--- a/XpulpV2/64bit/src/LinearQuant/pulp_nn_linear_u2_i8_i2.c
+++ b/XpulpV2/64bit/src/LinearQuant/pulp_nn_linear_u2_i8_i2.c
@@ -187,10 +187,10 @@ void pulp_nn_linear_u2_i8_i2(
         }
         if (flag_batch_norm && flag_relu)
         {
-          *pOutBuffer = pulp_nn_bn_quant_i8(sum, *pKappa, *pLambda, out_shift);
+          *pOutBuffer = pulp_nn_bn_quant_i8(sum, *k1, *lambda1, out_shift);
           pOutBuffer++;
-          pKappa++;
-          pLambda++;
+          k1++;
+          lambda1++;
         }
         else
         {

--- a/XpulpV2/64bit/src/LinearQuant/pulp_nn_linear_u2_i8_i4.c
+++ b/XpulpV2/64bit/src/LinearQuant/pulp_nn_linear_u2_i8_i4.c
@@ -196,10 +196,10 @@ void pulp_nn_linear_u2_i8_i4(
         }
         if (flag_batch_norm && flag_relu)
         {
-          *pOutBuffer = pulp_nn_bn_quant_i8(sum, *pKappa, *pLambda, out_shift);
+          *pOutBuffer = pulp_nn_bn_quant_i8(sum, *k1, *lambda1, out_shift);
           pOutBuffer++;
-          pKappa++;
-          pLambda++;
+          k1++;
+          lambda1++;
         }
         else
         {

--- a/XpulpV2/64bit/src/LinearQuant/pulp_nn_linear_u2_i8_i8.c
+++ b/XpulpV2/64bit/src/LinearQuant/pulp_nn_linear_u2_i8_i8.c
@@ -214,10 +214,10 @@ void pulp_nn_linear_u2_i8_i8(
         }
         if (flag_batch_norm && flag_relu)
         {
-          *pOutBuffer = pulp_nn_bn_quant_i8(sum, *pKappa, *pLambda, out_shift);
+          *pOutBuffer = pulp_nn_bn_quant_i8(sum, *k1, *lambda1, out_shift);
           pOutBuffer++;
-          pKappa++;
-          pLambda++;
+          k1++;
+          lambda1++;
         }
         else
         {

--- a/XpulpV2/64bit/src/LinearQuant/pulp_nn_linear_u2_u8_i2.c
+++ b/XpulpV2/64bit/src/LinearQuant/pulp_nn_linear_u2_u8_i2.c
@@ -187,10 +187,10 @@ void pulp_nn_linear_u2_u8_i2(
         }
         if (flag_batch_norm && flag_relu)
         {
-          *pOutBuffer = pulp_nn_bn_quant_u8(sum, *pKappa, *pLambda, out_shift);
+          *pOutBuffer = pulp_nn_bn_quant_u8(sum, *k1, *lambda1, out_shift);
           pOutBuffer++;
-          pKappa++;
-          pLambda++;
+          k1++;
+          lambda1++;
         }
         else
         {

--- a/XpulpV2/64bit/src/LinearQuant/pulp_nn_linear_u2_u8_i4.c
+++ b/XpulpV2/64bit/src/LinearQuant/pulp_nn_linear_u2_u8_i4.c
@@ -196,10 +196,10 @@ void pulp_nn_linear_u2_u8_i4(
         }
         if (flag_batch_norm && flag_relu)
         {
-          *pOutBuffer = pulp_nn_bn_quant_u8(sum, *pKappa, *pLambda, out_shift);
+          *pOutBuffer = pulp_nn_bn_quant_u8(sum, *k1, *lambda1, out_shift);
           pOutBuffer++;
-          pKappa++;
-          pLambda++;
+          k1++;
+          lambda1++;
         }
         else
         {

--- a/XpulpV2/64bit/src/LinearQuant/pulp_nn_linear_u2_u8_i8.c
+++ b/XpulpV2/64bit/src/LinearQuant/pulp_nn_linear_u2_u8_i8.c
@@ -214,10 +214,10 @@ void pulp_nn_linear_u2_u8_i8(
         }
         if (flag_batch_norm && flag_relu)
         {
-          *pOutBuffer = pulp_nn_bn_quant_u8(sum, *pKappa, *pLambda, out_shift);
+          *pOutBuffer = pulp_nn_bn_quant_u8(sum, *k1, *lambda1, out_shift);
           pOutBuffer++;
-          pKappa++;
-          pLambda++;
+          k1++;
+          lambda1++;
         }
         else
         {

--- a/XpulpV2/64bit/src/LinearQuant/pulp_nn_linear_u4_i8_i2.c
+++ b/XpulpV2/64bit/src/LinearQuant/pulp_nn_linear_u4_i8_i2.c
@@ -188,10 +188,10 @@ void pulp_nn_linear_u4_i8_i2(
         }
         if (flag_batch_norm && flag_relu)
         {
-          *pOutBuffer = pulp_nn_bn_quant_i8(sum, *pKappa, *pLambda, out_shift);
+          *pOutBuffer = pulp_nn_bn_quant_i8(sum, *k1, *lambda1, out_shift);
           pOutBuffer++;
-          pKappa++;
-          pLambda++;
+          k1++;
+          lambda1++;
         }
         else
         {

--- a/XpulpV2/64bit/src/LinearQuant/pulp_nn_linear_u4_i8_i4.c
+++ b/XpulpV2/64bit/src/LinearQuant/pulp_nn_linear_u4_i8_i4.c
@@ -165,10 +165,10 @@ void pulp_nn_linear_u4_i8_i4(
         }
         if (flag_batch_norm && flag_relu)
         {
-          *pOutBuffer = pulp_nn_bn_quant_i8(sum, *pKappa, *pLambda, out_shift);
+          *pOutBuffer = pulp_nn_bn_quant_i8(sum, *k1, *lambda1, out_shift);
           pOutBuffer++;
-          pKappa++;
-          pLambda++;
+          k1++;
+          lambda1++;
         }
         else
         {

--- a/XpulpV2/64bit/src/LinearQuant/pulp_nn_linear_u4_i8_i8.c
+++ b/XpulpV2/64bit/src/LinearQuant/pulp_nn_linear_u4_i8_i8.c
@@ -174,10 +174,10 @@ void pulp_nn_linear_u4_i8_i8(
         }
         if (flag_batch_norm && flag_relu)
         {
-          *pOutBuffer = pulp_nn_bn_quant_i8(sum, *pKappa, *pLambda, out_shift);
+          *pOutBuffer = pulp_nn_bn_quant_i8(sum, *k1, *lambda1, out_shift);
           pOutBuffer++;
-          pKappa++;
-          pLambda++;
+          k1++;
+          lambda1++;
         }
         else
         {

--- a/XpulpV2/64bit/src/LinearQuant/pulp_nn_linear_u4_u8_i2.c
+++ b/XpulpV2/64bit/src/LinearQuant/pulp_nn_linear_u4_u8_i2.c
@@ -188,10 +188,10 @@ void pulp_nn_linear_u4_u8_i2(
         }
         if (flag_batch_norm && flag_relu)
         {
-          *pOutBuffer = pulp_nn_bn_quant_u8(sum, *pKappa, *pLambda, out_shift);
+          *pOutBuffer = pulp_nn_bn_quant_u8(sum, *k1, *lambda1, out_shift);
           pOutBuffer++;
-          pKappa++;
-          pLambda++;
+          k1++;
+          lambda1++;
         }
         else
         {

--- a/XpulpV2/64bit/src/LinearQuant/pulp_nn_linear_u4_u8_i4.c
+++ b/XpulpV2/64bit/src/LinearQuant/pulp_nn_linear_u4_u8_i4.c
@@ -165,10 +165,10 @@ void pulp_nn_linear_u4_u8_i4(
         }
         if (flag_batch_norm && flag_relu)
         {
-          *pOutBuffer = pulp_nn_bn_quant_u8(sum, *pKappa, *pLambda, out_shift);
+          *pOutBuffer = pulp_nn_bn_quant_u8(sum, *k1, *lambda1, out_shift);
           pOutBuffer++;
-          pKappa++;
-          pLambda++;
+          k1++;
+          lambda1++;
         }
         else
         {

--- a/XpulpV2/64bit/src/LinearQuant/pulp_nn_linear_u4_u8_i8.c
+++ b/XpulpV2/64bit/src/LinearQuant/pulp_nn_linear_u4_u8_i8.c
@@ -174,10 +174,10 @@ void pulp_nn_linear_u4_u8_i8(
         }
         if (flag_batch_norm && flag_relu)
         {
-          *pOutBuffer = pulp_nn_bn_quant_u8(sum, *pKappa, *pLambda, out_shift);
+          *pOutBuffer = pulp_nn_bn_quant_u8(sum, *k1, *lambda1, out_shift);
           pOutBuffer++;
-          pKappa++;
-          pLambda++;
+          k1++;
+          lambda1++;
         }
         else
         {

--- a/XpulpV2/64bit/src/LinearQuant/pulp_nn_linear_u8_i8_i2.c
+++ b/XpulpV2/64bit/src/LinearQuant/pulp_nn_linear_u8_i8_i2.c
@@ -200,10 +200,10 @@ void pulp_nn_linear_u8_i8_i2(
         }
         if (flag_batch_norm && flag_relu)
         {
-          *pOutBuffer = pulp_nn_bn_quant_i8(sum, *pKappa, *pLambda, out_shift);
+          *pOutBuffer = pulp_nn_bn_quant_i8(sum, *k1, *lambda1, out_shift);
           pOutBuffer++;
-          pKappa++;
-          pLambda++;
+          k1++;
+          lambda1++;
         }
         else
         {

--- a/XpulpV2/64bit/src/LinearQuant/pulp_nn_linear_u8_i8_i4.c
+++ b/XpulpV2/64bit/src/LinearQuant/pulp_nn_linear_u8_i8_i4.c
@@ -171,10 +171,10 @@ void pulp_nn_linear_u8_i8_i4(
         }
         if (flag_batch_norm && flag_relu)
         {
-          *pOutBuffer = pulp_nn_bn_quant_i8(sum, *pKappa, *pLambda, out_shift);
+          *pOutBuffer = pulp_nn_bn_quant_i8(sum, *k1, *lambda1, out_shift);
           pOutBuffer++;
-          pKappa++;
-          pLambda++;
+          k1++;
+          lambda1++;
         }
         else
         {

--- a/XpulpV2/64bit/src/LinearQuant/pulp_nn_linear_u8_i8_i8.c
+++ b/XpulpV2/64bit/src/LinearQuant/pulp_nn_linear_u8_i8_i8.c
@@ -154,10 +154,10 @@ void pulp_nn_linear_u8_i8_i8(
         }
         if (flag_batch_norm && flag_relu)
         {
-          *pOutBuffer = pulp_nn_bn_quant_i8(sum, *pKappa, *pLambda, out_shift);
+          *pOutBuffer = pulp_nn_bn_quant_i8(sum, *k1, *lambda1, out_shift);
           pOutBuffer++;
-          pKappa++;
-          pLambda++;
+          k1++;
+          lambda1++;
         }
         else
         {

--- a/XpulpV2/64bit/src/LinearQuant/pulp_nn_linear_u8_u8_i2.c
+++ b/XpulpV2/64bit/src/LinearQuant/pulp_nn_linear_u8_u8_i2.c
@@ -200,10 +200,10 @@ void pulp_nn_linear_u8_u8_i2(
         }
         if (flag_batch_norm && flag_relu)
         {
-          *pOutBuffer = pulp_nn_bn_quant_u8(sum, *pKappa, *pLambda, out_shift);
+          *pOutBuffer = pulp_nn_bn_quant_u8(sum, *k1, *lambda1, out_shift);
           pOutBuffer++;
-          pKappa++;
-          pLambda++;
+          k1++;
+          lambda1++;
         }
         else
         {

--- a/XpulpV2/64bit/src/LinearQuant/pulp_nn_linear_u8_u8_i4.c
+++ b/XpulpV2/64bit/src/LinearQuant/pulp_nn_linear_u8_u8_i4.c
@@ -171,10 +171,10 @@ void pulp_nn_linear_u8_u8_i4(
         }
         if (flag_batch_norm && flag_relu)
         {
-          *pOutBuffer = pulp_nn_bn_quant_u8(sum, *pKappa, *pLambda, out_shift);
+          *pOutBuffer = pulp_nn_bn_quant_u8(sum, *k1, *lambda1, out_shift);
           pOutBuffer++;
-          pKappa++;
-          pLambda++;
+          k1++;
+          lambda1++;
         }
         else
         {

--- a/XpulpV2/64bit/src/LinearQuant/pulp_nn_linear_u8_u8_i8.c
+++ b/XpulpV2/64bit/src/LinearQuant/pulp_nn_linear_u8_u8_i8.c
@@ -154,10 +154,10 @@ void pulp_nn_linear_u8_u8_i8(
         }
         if (flag_batch_norm && flag_relu)
         {
-          *pOutBuffer = pulp_nn_bn_quant_u8(sum, *pKappa, *pLambda, out_shift);
+          *pOutBuffer = pulp_nn_bn_quant_u8(sum, *k1, *lambda1, out_shift);
           pOutBuffer++;
-          pKappa++;
-          pLambda++;
+          k1++;
+          lambda1++;
         }
         else
         {

--- a/generators/templates/pulp_nn_linear_q_x_y_z.t
+++ b/generators/templates/pulp_nn_linear_q_x_y_z.t
@@ -824,10 +824,10 @@ void ${config.fn_name}(
         }
         if (flag_batch_norm && flag_relu)
         {
-          *pOutBuffer = ${config.bn_fn}(sum, *pKappa, *pLambda, out_shift);
+          *pOutBuffer = ${config.bn_fn}(sum, *k1, *lambda1, out_shift);
           pOutBuffer++;
-          pKappa++;
-          pLambda++;
+          k1++;
+          lambda1++;
         }
         else
         {


### PR DESCRIPTION
## Summary

In the per-core leftover-neurons branch of every `pulp_nn_linear_*` kernel (and the corresponding `pulp_nn_linear_q_x_y_z.t` generator template), the batch-norm/requant call reads `*pKappa` / `*pLambda` instead of the per-core advanced pointers `*k1` / `*lambda1`. `pKappa` and `pLambda` are the original function arguments and always alias element 0, so any core that processes its neuron through the leftover path applies the *first* output neuron's BN parameters (kappa[0], lambda[0]) instead of its own.

## Reproducer

Easiest visible failure: the final classifier of MLPerf VisualWakeWords (MobilenetV1, 96x96, GAP9 deployment via Deeploy). The classifier is a fused RequantizedGemm with num_o_neurons=2 and NUM_CORES=8, so:

  * chunk = (2 >> 3) + ((2 & 7) != 0) = 1
  * core 0: start=0, stop=1, lft_neurons=1 → leftover path → reads *pKappa=kappa[0], *pLambda=lambda[0] → output[0] correct
  * core 1: start=1, stop=2, lft_neurons=1 → leftover path → **also** reads *pKappa=kappa[0], *pLambda=lambda[0] → output[1] uses lambda[0] instead of lambda[1]

Concretely on VWW (uint8 input is all-zero at this stage, so sum=0):
- expected output [bias[0]>>16, bias[1]>>16] = [7, -5]
- observed output [7, 7] (both neurons get bias[0])

## Fix

In every leftover-neuron branch:

```c
-      *pOutBuffer = pulp_nn_bn_quant_*(sum, *pKappa, *pLambda, out_shift);
-      pKappa++; pLambda++;
+      *pOutBuffer = pulp_nn_bn_quant_*(sum, *k1, *lambda1, out_shift);
+      k1++; lambda1++;
```

`k1` and `lambda1` are the per-core pointers the function header already initialises with `pKappa + start` / `pLambda + start`, then advances inside the main loop — they are the right pointers to use in the leftover branch too. The same correction is applied to the `pulp_nn_linear_q_x_y_z.t` generator template so this can't regress on the next regen.
